### PR TITLE
v0.2.0: map3, 4, 5, and 6 + improved expert API

### DIFF
--- a/incremental-map/src/btree_map.rs
+++ b/incremental-map/src/btree_map.rs
@@ -141,7 +141,7 @@ where
     let state = lhs.state();
     let prev_map: Rc<RefCell<BTreeMap<K, V>>> = Rc::new(RefCell::new(BTreeMap::new()));
     let acc = Rc::new(RefCell::new(BTreeMap::<K, V2>::new()));
-    let result = Node::<BTreeMap<K, V2>, O::Output>::new(&state, {
+    let result = Node::<BTreeMap<K, V2>>::new(&state, {
         let acc_ = acc.clone();
         move || acc_.borrow().clone()
     });
@@ -162,7 +162,7 @@ where
         }
     };
 
-    let mut prev_nodes = BTreeMap::<K, (WeakNode<_, _>, Dependency<O::Output>)>::new();
+    let mut prev_nodes = BTreeMap::<K, (WeakNode<_>, Dependency<O::Output>)>::new();
     let result_weak = result.weak();
 
     let lhs_change = lhs.map_cyclic({
@@ -201,7 +201,7 @@ where
                             node.watch().set_cutoff(cutoff);
                         }
                         let lhs_change = lhs_change.upgrade().unwrap();
-                        node.add_dependency_unit(&lhs_change);
+                        node.add_dependency(&lhs_change);
                         let mapped = f.call_fn(&key, node.watch());
                         let user_function_dep = result_weak.add_dependency_with(&mapped, {
                             let key = key.clone();
@@ -216,7 +216,7 @@ where
             *prev_map_mut = map.clone();
         }
     });
-    result.add_dependency_unit(&lhs_change);
+    result.add_dependency(&lhs_change);
     result.watch()
 }
 

--- a/incremental-map/src/im_rc.rs
+++ b/incremental-map/src/im_rc.rs
@@ -369,7 +369,7 @@ where
     let state = lhs.state();
     let prev_map = Rc::new(RefCell::new(OrdMap::<K, V>::new()));
     let acc = Rc::new(RefCell::new(OrdMap::new()));
-    let result = Node::<OrdMap<K, V2>, O::Output>::new(&state, {
+    let result = Node::<OrdMap<K, V2>>::new(&state, {
         let acc_ = acc.clone();
         move || OrdMap::clone(&acc_.borrow())
     });
@@ -389,7 +389,7 @@ where
             drop(acc);
         }
     };
-    let mut prev_nodes = OrdMap::<K, (WeakNode<_, _>, Dependency<_>)>::new();
+    let mut prev_nodes = OrdMap::<K, (WeakNode<_>, Dependency<_>)>::new();
     let result_weak = result.weak();
 
     // this one is just moved into the closure
@@ -429,7 +429,7 @@ where
                             node.watch().set_cutoff(cutoff);
                         }
                         let lhs_change = lhs_change.upgrade().unwrap();
-                        node.add_dependency_unit(&lhs_change);
+                        node.add_dependency(&lhs_change);
                         let mapped: Incr<O::Output> = f.call_fn(&key, node.watch());
                         let user_function_dep: Dependency<O::Output> = result_weak
                             .add_dependency_with(&mapped, {
@@ -445,6 +445,6 @@ where
             *prev_map_mut = map.clone();
         }
     });
-    result.add_dependency_unit(&lhs_change);
+    result.add_dependency(&lhs_change);
     result.watch()
 }

--- a/src/incr.rs
+++ b/src/incr.rs
@@ -91,18 +91,18 @@ impl<T: Value> Incr<T> {
     /// applying it to self. This enables you to put your own functions
     /// into the middle of a chain of method calls on Incr.
     #[inline]
-    pub fn pipe<R>(&self, mut f: impl FnMut(Incr<T>) -> Incr<R>) -> Incr<R> {
+    pub fn pipe<R>(&self, f: impl FnOnce(Incr<T>) -> Incr<R>) -> Incr<R> {
         // clones are cheap.
         f(self.clone())
     }
 
-    pub fn pipe1<R, A1>(&self, mut f: impl FnMut(Incr<T>, A1) -> Incr<R>, arg1: A1) -> Incr<R> {
+    pub fn pipe1<R, A1>(&self, f: impl FnOnce(Incr<T>, A1) -> Incr<R>, arg1: A1) -> Incr<R> {
         f(self.clone(), arg1)
     }
 
     pub fn pipe2<R, A1, A2>(
         &self,
-        mut f: impl FnMut(Incr<T>, A1, A2) -> Incr<R>,
+        f: impl FnOnce(Incr<T>, A1, A2) -> Incr<R>,
         arg1: A1,
         arg2: A2,
     ) -> Incr<R> {

--- a/src/incr.rs
+++ b/src/incr.rs
@@ -241,7 +241,6 @@ impl<T: Value> Incr<T> {
             state.current_scope.borrow().clone(),
             Kind::Map2(mapper),
         );
-
         Incr { node }
     }
 

--- a/src/incr.rs
+++ b/src/incr.rs
@@ -109,7 +109,7 @@ impl<T: Value> Incr<T> {
         f(self.clone(), arg1, arg2)
     }
 
-    /// A simple variation on `Incr::map` that tells you how many
+    /// A simple variation on [Incr::map] that tells you how many
     /// times the incremental has recomputed before this time.
     pub fn enumerate<R, F>(&self, mut f: F) -> Incr<R>
     where
@@ -171,7 +171,7 @@ impl<T: Value> Incr<T> {
     /// closure.
     ///
     /// Useful for advanced usage where you want to add manual dependencies with the
-    /// `incremental::expert` constructs.
+    /// [incremental::expert] constructs.
     pub fn map_cyclic<R: Value>(
         &self,
         mut cyclic: impl FnMut(WeakIncr<R>, &T) -> R + 'static,
@@ -199,14 +199,14 @@ impl<T: Value> Incr<T> {
         Incr { node }
     }
 
-    /// A version of `Incr::map` that allows reuse of the old
+    /// A version of [Incr::map] that allows reuse of the old
     /// value. You can use it to produce a new value. The main
     /// use case is avoiding allocation.
     ///
     /// The return type of the closure is `(R, bool)`. The boolean
-    /// value is a replacement for the `Cutoff` system, because
-    /// the `Cutoff` functions require access to an old value and
-    /// a new value. With `map_with_old`, you must figure out yourself
+    /// value is a replacement for the [Cutoff] system, because
+    /// the [Cutoff] functions require access to an old value and
+    /// a new value. With [Incr::map_with_old], you must figure out yourself
     /// (without relying on PartialEq, for example) whether the
     /// incremental node should propagate its changes.
     ///
@@ -245,7 +245,7 @@ impl<T: Value> Incr<T> {
         Incr { node }
     }
 
-    /// A version of bind that includes a copy of the `incremental::State`
+    /// A version of bind that includes a copy of the [IncrState] (as [WeakState])
     /// to help you construct new incrementals within the bind.
     pub fn binds<F, R>(&self, mut f: F) -> Incr<R>
     where
@@ -341,9 +341,9 @@ impl<T: Value> Incr<T> {
     /// Sets the cutoff function that determines (if it returns true)
     /// whether to stop (cut off) propagating changes through the graph.
     /// Note that this method can be called on `Var` as well as any
-    /// other `Incr`.
+    /// other [Incr].
     ///
-    /// The default is `Cutoff::PartialEq`. So if your values do not change,
+    /// The default is [Cutoff::PartialEq]. So if your values do not change,
     /// they will cut off propagation. There is a bound on all T in
     /// `Incr<T>` used in incremental-rs, all values you pass around
     /// must be PartialEq.
@@ -354,7 +354,7 @@ impl<T: Value> Incr<T> {
     /// and simply compare the allocation's pointer value instead.
     /// In that case, you can:
     ///
-    /// ```
+    /// ```rust
     /// use std::rc::Rc;
     /// use incremental::{IncrState, Cutoff};
     /// let incr = IncrState::new();
@@ -375,14 +375,13 @@ impl<T: Value> Incr<T> {
     /// closures, can be cast to a function pointer because they won't
     /// capture any values.
     ///
-    /// ```
+    /// ```rust
     /// use incremental::IncrState;
     /// let incr = IncrState::new();
     /// let var = incr.var(5);
     /// var.set_cutoff_fn(|a, b| a == b);
     /// var.set_cutoff_fn(i32::eq);
     /// var.set_cutoff_fn(PartialEq::eq);
-    /// // ...
     /// ```
     pub fn set_cutoff_fn(&self, cutoff_fn: fn(&T, &T) -> bool) {
         self.node.set_cutoff(Cutoff::Fn(cutoff_fn));
@@ -391,9 +390,8 @@ impl<T: Value> Incr<T> {
     /// A shorthand for using [Incr::set_cutoff] with [Cutoff::FnBoxed] and
     /// a closure that may capture its environment and mutate its captures.
     ///
-    /// ```
-    /// # use std::cell::Cell;
-    /// # use std::rc::Rc;
+    /// ```rust
+    /// use std::{cell::Cell, rc::Rc};
     /// use incremental::IncrState;
     /// let incr = IncrState::new();
     /// let var = incr.var(5);

--- a/src/kind.rs
+++ b/src/kind.rs
@@ -5,6 +5,40 @@ use super::node::Node;
 use super::var::Var;
 use crate::{Incr, Value};
 
+#[macro_export]
+macro_rules! node_generics_default {
+    (@fn $name:ident ( $($param:ident),* )) => {
+        type $name = fn($(&Self::$param,)*) -> Self::R;
+    };
+    (F1) => { node_generics_default!{ @fn F1 (I1) } };
+    (F2) => { node_generics_default!{ @fn F2 (I1, I2) } };
+    (F3) => { node_generics_default!{ @fn F3 (I1, I2, I3) } };
+    (F4) => { node_generics_default!{ @fn F4 (I1, I2, I3, I4) } };
+    (F5) => { node_generics_default!{ @fn F5 (I1, I2, I3, I4, I5) } };
+
+    (I1) => { type I1 = (); };
+    (I2) => { type I2 = (); };
+    (I3) => { type I3 = (); };
+    (I4) => { type I4 = (); };
+    (I5) => { type I5 = (); };
+
+    (BindLhs) => { type BindLhs = (); };
+    (BindRhs) => { type BindRhs = (); };
+    (B1) => { type B1 = fn(&Self::BindLhs) -> Incr<Self::BindRhs>; };
+    (Fold) => { type Fold = fn(Self::R, &Self::I1) -> Self::R; };
+    (Update) => { type Update = fn(Self::R, &Self::I1, &Self::I1) -> Self::R; };
+    (WithOld) => { type WithOld = fn(Option<Self::R>, &Self::I1) -> (Self::R, bool); };
+    (FRef) => { type FRef = fn(&Self::I1) -> &Self::R; };
+    (Recompute) => { type Recompute = fn() -> Self::R; };
+    (ObsChange) => { type ObsChange = fn(bool); };
+
+    ($($ident:ident),*) => {
+        $(
+            node_generics_default! { $ident }
+        )*
+    }
+}
+
 mod array_fold;
 mod bind;
 pub(crate) mod expert;
@@ -21,9 +55,15 @@ pub(crate) trait NodeGenerics: 'static {
     type BindRhs: Value;
     type I1: Value;
     type I2: Value;
+    type I3: Value;
+    type I4: Value;
+    type I5: Value;
     type F1: FnMut(&Self::I1) -> Self::R;
     type FRef: Fn(&Self::I1) -> &Self::R;
     type F2: FnMut(&Self::I1, &Self::I2) -> Self::R;
+    type F3: FnMut(&Self::I1, &Self::I2, &Self::I3) -> Self::R;
+    type F4: FnMut(&Self::I1, &Self::I2, &Self::I3, &Self::I4) -> Self::R;
+    type F5: FnMut(&Self::I1, &Self::I2, &Self::I3, &Self::I4, &Self::I5) -> Self::R;
     type B1: FnMut(&Self::BindLhs) -> Incr<Self::BindRhs>;
     type Fold: FnMut(Self::R, &Self::I1) -> Self::R;
     type Update: FnMut(Self::R, &Self::I1, &Self::I1) -> Self::R;
@@ -42,6 +82,9 @@ pub(crate) enum Kind<G: NodeGenerics> {
     MapWithOld(map::MapWithOld<G::WithOld, G::I1, G::R>),
     MapRef(map::MapRefNode<G::FRef, G::I1, G::R>),
     Map2(map::Map2Node<G::F2, G::I1, G::I2, G::R>),
+    Map3(map::Map3Node<G::F3, G::I1, G::I2, G::I3, G::R>),
+    Map4(map::Map4Node<G::F4, G::I1, G::I2, G::I3, G::I4, G::R>),
+    Map5(map::Map5Node<G::F5, G::I1, G::I2, G::I3, G::I4, G::I5, G::R>),
     BindLhsChange {
         casts: bind::BindLhsId<G>,
         bind: Rc<bind::BindNode<G::B1, G::BindLhs, G::BindRhs>>,
@@ -66,7 +109,10 @@ impl<G: NodeGenerics> Debug for Kind<G> {
             Kind::Var(var) => write!(f, "Var({:?})", var),
             Kind::Map(map) => write!(f, "Map({:?})", map),
             Kind::MapWithOld(map) => write!(f, "MapWithOld({:?})", map),
-            Kind::Map2(map2) => write!(f, "Map2({:?})", map2),
+            Kind::Map2(map) => write!(f, "Map2({:?})", map),
+            Kind::Map3(map) => write!(f, "Map3({:?})", map),
+            Kind::Map4(map) => write!(f, "Map4({:?})", map),
+            Kind::Map5(map) => write!(f, "Map5({:?})", map),
             Kind::BindLhsChange { bind, .. } => write!(f, "BindLhsChange({:?})", bind),
             Kind::BindMain { bind, .. } => write!(f, "BindMain({:?})", bind),
             Kind::MapRef(mapref) => write!(f, "MapRef({:?})", mapref),
@@ -84,6 +130,9 @@ impl<G: NodeGenerics> Kind<G> {
             Self::Var(_) => 0,
             Self::Map(_) | Self::MapWithOld(_) | Self::MapRef(_) => 1,
             Self::Map2(_) => 2,
+            Self::Map3(_) => 3,
+            Self::Map4(_) => 4,
+            Self::Map5(_) => 5,
             Self::BindLhsChange { .. } => 1,
             Self::BindMain { .. } => 2,
             Self::Expert(_) => 0,
@@ -95,17 +144,7 @@ pub(crate) struct Constant<T>(std::marker::PhantomData<T>);
 
 impl<T: Value> NodeGenerics for Constant<T> {
     type R = T;
-    type BindLhs = ();
-    type BindRhs = ();
-    type I1 = ();
-    type I2 = ();
-    type F1 = fn(&Self::I1) -> Self::R;
-    type F2 = fn(&Self::I1, &Self::I2) -> Self::R;
-    type B1 = fn(&Self::BindLhs) -> Incr<Self::BindRhs>;
-    type Fold = fn(Self::R, &Self::I1) -> Self::R;
-    type Update = fn(Self::R, &Self::I1, &Self::I1) -> Self::R;
-    type WithOld = fn(Option<Self::R>, &Self::I1) -> (Self::R, bool);
-    type FRef = fn(&Self::I1) -> &Self::R;
-    type Recompute = fn() -> Self::R;
-    type ObsChange = fn(bool);
+    node_generics_default! { I1, I2, I3, I4, I5 }
+    node_generics_default! { F1, F2, F3, F4, F5 }
+    node_generics_default! { B1, BindLhs, BindRhs, Fold, Update, WithOld, FRef, Recompute, ObsChange }
 }

--- a/src/kind.rs
+++ b/src/kind.rs
@@ -98,7 +98,7 @@ pub(crate) enum Kind<G: NodeGenerics> {
         // BindNode holds weak refs to both
         lhs_change: Rc<Node<bind::BindLhsChangeGen<G::B1, G::BindLhs, G::BindRhs>>>,
     },
-    Expert(expert::ExpertNode<G::R, G::I1, G::Recompute, G::ObsChange>),
+    Expert(expert::ExpertNode<G::R, G::Recompute, G::ObsChange>),
 }
 
 impl<G: NodeGenerics> Debug for Kind<G> {

--- a/src/kind/array_fold.rs
+++ b/src/kind/array_fold.rs
@@ -32,8 +32,8 @@ where
     type R = R;
     type I1 = I;
     type Fold = F;
-    node_generics_default! { I2, I3, I4, I5 }
-    node_generics_default! { F1, F2, F3, F4, F5 }
+    node_generics_default! { I2, I3, I4, I5, I6 }
+    node_generics_default! { F1, F2, F3, F4, F5, F6 }
     node_generics_default! { B1, BindLhs, BindRhs, Update, WithOld, FRef, Recompute, ObsChange }
 }
 

--- a/src/kind/array_fold.rs
+++ b/src/kind/array_fold.rs
@@ -30,19 +30,11 @@ where
     F: FnMut(R, &I) -> R + 'static,
 {
     type R = R;
-    type BindLhs = ();
-    type BindRhs = ();
     type I1 = I;
-    type I2 = ();
-    type F1 = fn(&Self::I1) -> R;
-    type F2 = fn(&Self::I1, &Self::I2) -> R;
-    type B1 = fn(&Self::BindLhs) -> Incr<Self::BindRhs>;
     type Fold = F;
-    type Update = fn(Self::R, &Self::I1, &Self::I1) -> Self::R;
-    type WithOld = fn(Option<Self::R>, &Self::I1) -> (Self::R, bool);
-    type FRef = fn(&Self::I1) -> &Self::R;
-    type Recompute = fn() -> Self::R;
-    type ObsChange = fn(bool);
+    node_generics_default! { I2, I3, I4, I5 }
+    node_generics_default! { F1, F2, F3, F4, F5 }
+    node_generics_default! { B1, BindLhs, BindRhs, Update, WithOld, FRef, Recompute, ObsChange }
 }
 
 impl<F, I, R> Debug for ArrayFold<F, I, R>

--- a/src/kind/bind.rs
+++ b/src/kind/bind.rs
@@ -79,8 +79,8 @@ where
     type I1 = ();
     type I2 = T;
     type B1 = F;
-    node_generics_default! { I3, I4, I5 }
-    node_generics_default! { F1, F2, F3, F4, F5 }
+    node_generics_default! { I3, I4, I5, I6 }
+    node_generics_default! { F1, F2, F3, F4, F5, F6 }
     node_generics_default! { Fold, Update, WithOld, FRef, Recompute, ObsChange }
 }
 
@@ -103,8 +103,8 @@ where
     /// BindLhsChange (a sentinel)
     type I2 = ();
     type B1 = F;
-    node_generics_default! { I3, I4, I5 }
-    node_generics_default! { F1, F2, F3, F4, F5 }
+    node_generics_default! { I3, I4, I5, I6 }
+    node_generics_default! { F1, F2, F3, F4, F5, F6 }
     node_generics_default! { Fold, Update, WithOld, FRef, Recompute, ObsChange }
 }
 

--- a/src/kind/bind.rs
+++ b/src/kind/bind.rs
@@ -74,15 +74,10 @@ where
     // swap order so we can use as_parent with I1
     type I1 = ();
     type I2 = T;
-    type F1 = fn(&Self::I1) -> Self::R;
-    type F2 = fn(&Self::I1, &Self::I2) -> Self::R;
     type B1 = F;
-    type Fold = fn(Self::R, &Self::I1) -> Self::R;
-    type Update = fn(Self::R, &Self::I1, &Self::I1) -> Self::R;
-    type WithOld = fn(Option<Self::R>, &Self::I1) -> (Self::R, bool);
-    type FRef = fn(&Self::I1) -> &Self::R;
-    type Recompute = fn() -> Self::R;
-    type ObsChange = fn(bool);
+    node_generics_default! { I3, I4, I5 }
+    node_generics_default! { F1, F2, F3, F4, F5 }
+    node_generics_default! { Fold, Update, WithOld, FRef, Recompute, ObsChange }
 }
 
 pub(crate) struct BindNodeMainGen<F, T, R> {
@@ -103,15 +98,10 @@ where
     type I1 = R;
     /// BindLhsChange (a sentinel)
     type I2 = ();
-    type F1 = fn(&Self::I1) -> Self::R;
-    type F2 = fn(&Self::I1, &Self::I2) -> Self::R;
     type B1 = F;
-    type Fold = fn(Self::R, &Self::I1) -> Self::R;
-    type Update = fn(Self::R, &Self::I1, &Self::I1) -> Self::R;
-    type WithOld = fn(Option<Self::R>, &Self::I1) -> (Self::R, bool);
-    type FRef = fn(&Self::I1) -> &Self::R;
-    type Recompute = fn() -> Self::R;
-    type ObsChange = fn(bool);
+    node_generics_default! { I3, I4, I5 }
+    node_generics_default! { F1, F2, F3, F4, F5 }
+    node_generics_default! { Fold, Update, WithOld, FRef, Recompute, ObsChange }
 }
 
 impl<F, T, R> fmt::Debug for BindNode<F, T, R>

--- a/src/kind/bind.rs
+++ b/src/kind/bind.rs
@@ -37,12 +37,16 @@ where
     }
     fn is_valid(&self) -> bool {
         let main_ = self.main.borrow();
-        let Some(main) = main_.upgrade() else { return false };
+        let Some(main) = main_.upgrade() else {
+            return false;
+        };
         main.is_valid()
     }
     fn is_necessary(&self) -> bool {
         let main_ = self.main.borrow();
-        let Some(main) = main_.upgrade() else { return false };
+        let Some(main) = main_.upgrade() else {
+            return false;
+        };
         main.is_necessary()
     }
     fn height(&self) -> i32 {

--- a/src/kind/expert.rs
+++ b/src/kind/expert.rs
@@ -161,15 +161,16 @@ where
             children.swap(one, two);
         });
     }
-    pub(crate) fn last_child_edge_exn(&self) -> PackedEdge {
+    pub(crate) fn last_child_edge(&self) -> Option<PackedEdge> {
         let children = self.children.borrow();
-        children.last().unwrap().clone()
+        children.last().cloned()
     }
-    pub(crate) fn remove_last_child_edge_exn(&self) {
+    pub(crate) fn pop_child_edge(&self) -> Option<PackedEdge> {
         let mut children = self.children.borrow_mut();
-        let packed_edge = children.pop().unwrap();
+        let packed_edge = children.pop()?;
         self.force_stale.set(true);
         packed_edge.index_cell().set(None);
+        Some(packed_edge)
     }
     pub(crate) fn before_main_computation(&self) -> Result<(), Invalid> {
         if self.num_invalid_children.get() > 0 {
@@ -367,7 +368,7 @@ pub mod public {
         /// (i.e. to invalidate it) then upgrade the WeakNode first.
         pub fn remove_dependency<D: Value>(&self, dep: Dependency<D>) {
             let edge = dep.edge.upgrade().unwrap();
-            expert::remove_dependency(&*self.incr.node, &*edge)
+            expert::remove_dependency(&*self.incr.node, &*edge);
         }
     }
 

--- a/src/kind/expert.rs
+++ b/src/kind/expert.rs
@@ -212,13 +212,17 @@ where
                 );
                 borrow_span.in_scope(|| {
                     let children = self.children.borrow();
-                    let Some(child) = children.get(child_index as usize) else {return None };
+                    let Some(child) = children.get(child_index as usize) else {
+                        return None;
+                    };
                     // clone the child, so we can drop the borrow of the children vector.
                     // the child on_change callback may add or remove children. It needs borrow_mut access!
                     Some(child.clone())
                 })
             };
-            let Some(child) = child else { return; };
+            let Some(child) = child else {
+                return;
+            };
             child.on_change()
         }
     }

--- a/src/kind/expert.rs
+++ b/src/kind/expert.rs
@@ -405,20 +405,6 @@ pub mod public {
         ) -> Dependency<D> {
             self.upgrade().unwrap().add_dependency_with(on, on_change)
         }
-        #[doc(hidden)]
-        #[deprecated = "add_dependency is now generic"]
-        pub fn add_dependency_unit(&self, on: &Incr<()>) -> Dependency<()> {
-            self.add_dependency(on)
-        }
-        #[doc(hidden)]
-        #[deprecated = "add_dependency_with is now generic"]
-        pub fn add_dependency_unit_with(
-            &self,
-            on: &Incr<()>,
-            on_change: impl FnMut(&()) + 'static,
-        ) -> Dependency<()> {
-            self.add_dependency_with(on, on_change)
-        }
         /// Caution: if the Dependency is on an expert::Node, then running this may cause
         /// a related WeakNode to be deallocated. If you wish to use the related node after
         /// (i.e. to invalidate it) then upgrade the WeakNode first.

--- a/src/kind/expert.rs
+++ b/src/kind/expert.rs
@@ -351,6 +351,15 @@ pub mod public {
             expert::add_dependency(&self.incr.node.packed(), edge);
             dep
         }
+        /// Add dependency with a change callback.
+        ///
+        /// Note that you should not use the change callback to
+        /// add or remove dependencies. The scheduler isn't smart enough to initialize such a
+        /// system and cut off any recursion that results, so it doesn't try. You can implement
+        /// Bind-like behaviour by introducing a Map node, adding/removing dynamic dependencies in
+        /// the Map function, and then adding a dependency on the Map node. The static dependency
+        /// on the Map node ensures all the dynamic dependnencies are resolved before the expert
+        /// Node runs. This way you also get cycle detection done by the system.
         pub fn add_dependency_with<D: Value>(
             &self,
             on: &Incr<D>,
@@ -398,6 +407,8 @@ pub mod public {
         pub fn add_dependency<D: Value>(&self, on: &Incr<D>) -> Dependency<D> {
             self.upgrade().unwrap().add_dependency(on)
         }
+        /// See [Node::add_dependency_with], noting especially that you should not use the on_change
+        /// callback to add dynamic dependencies to this expert node.
         pub fn add_dependency_with<D: Value>(
             &self,
             on: &Incr<D>,

--- a/src/kind/expert.rs
+++ b/src/kind/expert.rs
@@ -423,4 +423,11 @@ pub mod public {
             self.upgrade().unwrap().remove_dependency(dep)
         }
     }
+
+    impl<T: Value> AsRef<Incr<T>> for Node<T> {
+        #[inline]
+        fn as_ref(&self) -> &Incr<T> {
+            &self.incr
+        }
+    }
 }

--- a/src/kind/expert.rs
+++ b/src/kind/expert.rs
@@ -249,8 +249,8 @@ where
     type R = T;
     type Recompute = FRecompute;
     type ObsChange = FObsChange;
-    node_generics_default! { I1, I2, I3, I4, I5 }
-    node_generics_default! { F1, F2, F3, F4, F5 }
+    node_generics_default! { I1, I2, I3, I4, I5, I6 }
+    node_generics_default! { F1, F2, F3, F4, F5, F6 }
     node_generics_default! { B1, BindLhs, BindRhs }
     node_generics_default! { Fold, Update, WithOld, FRef }
 }

--- a/src/kind/expert.rs
+++ b/src/kind/expert.rs
@@ -200,19 +200,13 @@ where
     FObsChange: FnMut(bool) + 'static,
 {
     type R = T;
-    type BindLhs = ();
-    type BindRhs = ();
     type I1 = C;
     type I2 = ();
-    type F1 = fn(&Self::I1) -> Self::R;
-    type F2 = fn(&Self::I1, &Self::I2) -> Self::R;
-    type B1 = fn(&Self::BindLhs) -> Incr<Self::BindRhs>;
-    type Fold = fn(Self::R, &Self::I1) -> Self::R;
-    type Update = fn(Self::R, &Self::I1, &Self::I1) -> Self::R;
-    type WithOld = fn(Option<Self::R>, &Self::I1) -> (Self::R, bool);
-    type FRef = fn(&Self::I1) -> &Self::R;
     type Recompute = FRecompute;
     type ObsChange = FObsChange;
+    node_generics_default! { I3, I4, I5 }
+    node_generics_default! { F1, F2, F3, F4, F5 }
+    node_generics_default! { B1, BindLhs, BindRhs, Fold, Update, WithOld, FRef }
 }
 
 pub mod public {

--- a/src/kind/map.rs
+++ b/src/kind/map.rs
@@ -25,9 +25,9 @@ where
     type BindRhs = ();
     type I1 = T;
     type F1 = F;
-    node_generics_default! { I2, I3, I4, I5 }
-    node_generics_default! { F2, F3, F4, F5, B1 }
-    node_generics_default! { Fold, Update, WithOld, FRef, Recompute, ObsChange }
+    node_generics_default! { I2, I3, I4, I5, I6 }
+    node_generics_default! { F2, F3, F4, F5, F6 }
+    node_generics_default! { B1, Fold, Update, WithOld, FRef, Recompute, ObsChange }
 }
 
 impl<F, T, R> fmt::Debug for MapNode<F, T, R>
@@ -60,9 +60,9 @@ where
     type BindRhs = ();
     type I1 = T;
     type FRef = F;
-    node_generics_default! { I2, I3, I4, I5 }
-    node_generics_default! { F1, F2, F3, F4, F5, B1 }
-    node_generics_default! { Fold, Update, WithOld, Recompute, ObsChange }
+    node_generics_default! { I2, I3, I4, I5, I6 }
+    node_generics_default! { F1, F2, F3, F4, F5, F6 }
+    node_generics_default! { B1, Fold, Update, WithOld, Recompute, ObsChange }
 }
 
 impl<F, T, R> fmt::Debug for MapRefNode<F, T, R>
@@ -100,9 +100,9 @@ where
     type I2 = T2;
     type F1 = fn(&Self::I1) -> R;
     type F2 = F;
-    node_generics_default! { I3, I4, I5 }
-    node_generics_default! { F3, F4, F5, B1 }
-    node_generics_default! { Fold, Update, WithOld, FRef, Recompute, ObsChange }
+    node_generics_default! { I3, I4, I5, I6 }
+    node_generics_default! { F3, F4, F5, F6 }
+    node_generics_default! { B1, Fold, Update, WithOld, FRef, Recompute, ObsChange }
 }
 
 impl<F, T1, T2, R> fmt::Debug for Map2Node<F, T1, T2, R>
@@ -220,7 +220,7 @@ map_node! {
         }
         fn { mapper: F3(.., T2, T3) -> R, }
     > {
-        default < F1, F2, F4, F5, I4, I5 >,
+        default < F1, F2, F4, F5, F6, I4, I5, I6 >,
         impl Incr::map3, Kind::Map3
     }
 }
@@ -235,7 +235,7 @@ map_node! {
         }
         fn { mapper: F4(.., T2, T3, T4) -> R, }
     > {
-        default < F1, F2, F3, F5, I5 >,
+        default < F1, F2, F3, F5, F6, I5, I6 >,
         impl Incr::map4, Kind::Map4
     }
 }
@@ -251,8 +251,25 @@ map_node! {
         }
         fn { mapper: F5(.., T2, T3, T4, T5) -> R, }
     > {
-        default < F1, F2, F3, F4 >,
+        default < F1, F2, F3, F4, F6, I6 >,
         impl Incr::map5, Kind::Map5
+    }
+}
+
+map_node! {
+    pub(crate) struct Map6Node<
+        inputs {
+            one: T1 = I1,
+            two: T2 = I2,
+            three: T3 = I3,
+            four: T4 = I4,
+            five: T5 = I5,
+            six: T6 = I6,
+        }
+        fn { mapper: F6(.., T2, T3, T4, T5, T6) -> R, }
+    > {
+        default < F1, F2, F3, F4, F5 >,
+        impl Incr::map6, Kind::Map6
     }
 }
 
@@ -289,8 +306,8 @@ where
     type I1 = T;
     type R = R;
     type WithOld = F;
-    node_generics_default! { I2, I3, I4, I5 }
-    node_generics_default! { F1, F2, F3, F4, F5 }
+    node_generics_default! { I2, I3, I4, I5, I6 }
+    node_generics_default! { F1, F2, F3, F4, F5, F6 }
     node_generics_default! { B1, BindLhs, BindRhs }
     node_generics_default! { Fold, Update, FRef, Recompute, ObsChange }
 }

--- a/src/kind/map.rs
+++ b/src/kind/map.rs
@@ -185,6 +185,9 @@ macro_rules! map_node {
             }
         }
         impl<$t1: Value> Incr<$t1> {
+            /// Like [Incr::map] and [Incr::map2], but with more input incrementals.
+            ///
+            /// If you don't feel like counting, try using the `(i1 % i2 % ...).map((|_, _, ...| ...))` syntax.
             pub fn $methodname<$fparam, $($t2,)* $r>(&self, $($tfield: &Incr<$t>,)* f: $fparam) -> Incr<R>
             where
                 $($t: Value,)*

--- a/src/kind/map.rs
+++ b/src/kind/map.rs
@@ -24,16 +24,10 @@ where
     type BindLhs = ();
     type BindRhs = ();
     type I1 = T;
-    type I2 = ();
     type F1 = F;
-    type F2 = fn(&Self::I1, &Self::I2) -> R;
-    type B1 = fn(&Self::BindLhs) -> Incr<Self::BindRhs>;
-    type Fold = fn(Self::R, &Self::I1) -> Self::R;
-    type Update = fn(Self::R, &Self::I1, &Self::I1) -> Self::R;
-    type WithOld = fn(Option<Self::R>, &Self::I1) -> (Self::R, bool);
-    type FRef = fn(&Self::I1) -> &Self::R;
-    type Recompute = fn() -> Self::R;
-    type ObsChange = fn(bool);
+    node_generics_default! { I2, I3, I4, I5 }
+    node_generics_default! { F2, F3, F4, F5, B1 }
+    node_generics_default! { Fold, Update, WithOld, FRef, Recompute, ObsChange }
 }
 
 impl<F, T, R> fmt::Debug for MapNode<F, T, R>
@@ -65,16 +59,10 @@ where
     type BindLhs = ();
     type BindRhs = ();
     type I1 = T;
-    type I2 = ();
-    type F1 = fn(&Self::I1) -> R;
-    type F2 = fn(&Self::I1, &Self::I2) -> R;
-    type B1 = fn(&Self::BindLhs) -> Incr<Self::BindRhs>;
-    type Fold = fn(Self::R, &Self::I1) -> Self::R;
-    type Update = fn(Self::R, &Self::I1, &Self::I1) -> Self::R;
-    type WithOld = fn(Option<Self::R>, &Self::I1) -> (Self::R, bool);
     type FRef = F;
-    type Recompute = fn() -> Self::R;
-    type ObsChange = fn(bool);
+    node_generics_default! { I2, I3, I4, I5 }
+    node_generics_default! { F1, F2, F3, F4, F5, B1 }
+    node_generics_default! { Fold, Update, WithOld, Recompute, ObsChange }
 }
 
 impl<F, T, R> fmt::Debug for MapRefNode<F, T, R>
@@ -112,13 +100,9 @@ where
     type I2 = T2;
     type F1 = fn(&Self::I1) -> R;
     type F2 = F;
-    type B1 = fn(&Self::BindLhs) -> Incr<Self::BindRhs>;
-    type Fold = fn(Self::R, &Self::I1) -> Self::R;
-    type Update = fn(Self::R, &Self::I1, &Self::I1) -> Self::R;
-    type WithOld = fn(Option<Self::R>, &Self::I1) -> (Self::R, bool);
-    type FRef = fn(&Self::I1) -> &Self::R;
-    type Recompute = fn() -> Self::R;
-    type ObsChange = fn(bool);
+    node_generics_default! { I3, I4, I5 }
+    node_generics_default! { F3, F4, F5, B1 }
+    node_generics_default! { Fold, Update, WithOld, FRef, Recompute, ObsChange }
 }
 
 impl<F, T1, T2, R> fmt::Debug for Map2Node<F, T1, T2, R>
@@ -128,6 +112,147 @@ where
 {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         f.debug_struct("Map2Node").finish()
+    }
+}
+
+macro_rules! map_node {
+    (@rest) => {
+        node_generics_default! { B1, BindLhs, BindRhs }
+        node_generics_default! { Fold, Update, WithOld, FRef, Recompute, ObsChange }
+    };
+    (@FnMut $($param:ident,)*) => {
+        FnMut($($param,)*) -> Self::R
+    };
+    (@head $t1:ident, $($t2:ident,)*) => {
+        $t1
+    };
+    (@tail_args $tfield1:ident: $t1:ident, $($tfield2:ident: $t2:ident,)*) => {
+        $($tfield2: &Incr<$t2>,)*
+    };
+    (@tail_mapper $mapnode:ident { $f:ident, $self:ident, $tfield1:ident, $($tfield2:ident,)* }) => {
+        $mapnode {
+            $tfield1: $self.clone().node,
+            $($tfield2: $tfield2.clone().node,)*
+            mapper: $f.into(),
+        }
+    };
+    ($vis:vis struct $mapnode:ident <
+         inputs {
+             $tfield1:ident: $t1:ident = $i1:ident,
+             $(
+                 $tfield:ident : $t:ident = $i:ident,
+             )+
+         }
+         fn {
+             $ffield:ident : $fparam:ident(.., $($t2:ident),*) -> $r:ident,
+         }
+     > {
+         default < $($d:ident),* >,
+         impl Incr::$methodname:ident, Kind::$kind:ident
+     }) => {
+        $vis struct $mapnode <$fparam, $t1, $($t,)* $r>
+        where
+            $fparam : FnMut(&$t1, $(&$t2,)*) -> $r,
+            $r: Value,
+        {
+            $vis $tfield1: Input<$t1>,
+            $($vis $tfield: Input<$t>,)*
+            $vis $ffield: RefCell<$fparam>,
+        }
+
+        impl<$fparam, $t1, $($t,)* $r> NodeGenerics for $mapnode<$fparam, $t1, $($t2,)* $r>
+        where
+            $t1: Value,
+            $($t: Value,)*
+            $fparam : FnMut(&$t1, $(&$t2,)*) -> $r + 'static,
+            $r: Value,
+        {
+            map_node!{ @rest }
+            type R = $r;
+            type $i1 = $t1;
+            $(type $i = $t2;)*
+            type $fparam = $fparam;
+            crate::node_generics_default! { $($d),* }
+        }
+        impl<$fparam, $t1, $($t,)* $r> fmt::Debug for $mapnode<$fparam, $t1, $($t,)* $r>
+        where
+            $($t: Value,)*
+            $fparam : FnMut(&$t1, $(&$t2,)*) -> $r + 'static,
+            $r: Value,
+        {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+                f.debug_struct(stringify!($mapnode)).finish()
+            }
+        }
+        impl<$t1: Value> Incr<$t1> {
+            pub fn $methodname<$fparam, $($t2,)* $r>(&self, $($tfield: &Incr<$t>,)* f: $fparam) -> Incr<R>
+            where
+                $($t: Value,)*
+                $r: Value,
+                $fparam : FnMut(&$t1, $(&$t2,)*) -> $r + 'static,
+            {
+                let mapper = map_node! {
+                    @tail_mapper $mapnode {
+                        f,
+                        self,
+                        $tfield1,
+                        $($tfield,)*
+                    }
+                };
+                let state = self.node.state();
+                let node = crate::node::Node::<$mapnode<$fparam, $t1, $($t2,)* $r>>::create_rc(
+                    state.weak(),
+                    state.current_scope.borrow().clone(),
+                    crate::kind::Kind::$kind(mapper),
+                );
+                Incr { node }
+            }
+        }
+    };
+}
+
+map_node! {
+    pub(crate) struct Map3Node<
+        inputs {
+            one: T1 = I1,
+            two: T2 = I2,
+            three: T3 = I3,
+        }
+        fn { mapper: F3(.., T2, T3) -> R, }
+    > {
+        default < F1, F2, F4, F5, I4, I5 >,
+        impl Incr::map3, Kind::Map3
+    }
+}
+
+map_node! {
+    pub(crate) struct Map4Node<
+        inputs {
+            one: T1 = I1,
+            two: T2 = I2,
+            three: T3 = I3,
+            four: T4 = I4,
+        }
+        fn { mapper: F4(.., T2, T3, T4) -> R, }
+    > {
+        default < F1, F2, F3, F5, I5 >,
+        impl Incr::map4, Kind::Map4
+    }
+}
+
+map_node! {
+    pub(crate) struct Map5Node<
+        inputs {
+            one: T1 = I1,
+            two: T2 = I2,
+            three: T3 = I3,
+            four: T4 = I4,
+            five: T5 = I5,
+        }
+        fn { mapper: F5(.., T2, T3, T4, T5) -> R, }
+    > {
+        default < F1, F2, F3, F4 >,
+        impl Incr::map5, Kind::Map5
     }
 }
 
@@ -161,20 +286,13 @@ where
     // WARN: we ignore this boolean now
     F: FnMut(Option<R>, &T) -> (R, bool) + 'static,
 {
-    type R = R;
-    type BindLhs = ();
-    type BindRhs = ();
     type I1 = T;
-    type I2 = ();
-    type F1 = fn(&Self::I1) -> R;
-    type F2 = fn(&Self::I1, &Self::I2) -> R;
-    type B1 = fn(&Self::BindLhs) -> Incr<Self::BindRhs>;
-    type Fold = fn(Self::R, &Self::I1) -> Self::R;
-    type Update = fn(Self::R, &Self::I1, &Self::I1) -> Self::R;
+    type R = R;
     type WithOld = F;
-    type FRef = fn(&Self::I1) -> &Self::R;
-    type Recompute = fn() -> Self::R;
-    type ObsChange = fn(bool);
+    node_generics_default! { I2, I3, I4, I5 }
+    node_generics_default! { F1, F2, F3, F4, F5 }
+    node_generics_default! { B1, BindLhs, BindRhs }
+    node_generics_default! { Fold, Update, FRef, Recompute, ObsChange }
 }
 
 impl<F, T, R> fmt::Debug for MapWithOld<F, T, R>

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -92,6 +92,11 @@ pub(crate) fn weak_thin_ptr_eq<T: ?Sized>(one: &Weak<T>, two: &Weak<T>) -> bool 
     let two_: *const () = Weak::as_ptr(two).cast();
     one_ == two_
 }
+pub(crate) fn dyn_thin_ptr_eq<T: ?Sized>(one: &T, two: &T) -> bool {
+    let one_: *const () = one as *const T as *const ();
+    let two_: *const () = two as *const T as *const ();
+    one_ == two_
+}
 
 /// Little helper trait for bumping a statistic.
 pub(crate) trait CellIncrement {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,5 @@
 // #![feature(type_alias_impl_trait)]
 #![doc = include_str!("../README.md")]
-
 // We have some really complicated types. Most of them can't be typedef'd to be any shorter.
 #![allow(clippy::type_complexity)]
 // #![allow(clippy::single_match)]

--- a/src/node.rs
+++ b/src/node.rs
@@ -559,8 +559,7 @@ impl<G: NodeGenerics> Parent2<G::I2> for Node<G> {
         child_index: i32,
         _old_value_opt: Option<&G::I2>,
     ) -> Result<(), ParentError> {
-        let kind = self.kind().ok_or(ParentError::ParentInvalidated)?;
-        if let Some(Kind::Expert(expert)) = self.kind() {
+        if let Kind::Expert(expert) = self.kind().ok_or(ParentError::ParentInvalidated)? {
             expert.run_edge_callback(child_index)
         }
         Ok(())

--- a/src/node.rs
+++ b/src/node.rs
@@ -1620,7 +1620,7 @@ impl<G: NodeGenerics> ErasedNode for Node<G> {
         [add_dependency] */
         let edge_index = dyn_edge.index_cell().get().unwrap();
         let edge_child = dyn_edge.packed();
-        let last_edge = expert.last_child_edge_exn();
+        let last_edge = expert.last_child_edge().unwrap();
         let last_edge_index = last_edge.index_cell().get().unwrap();
         if edge_index != last_edge_index {
             if self.is_necessary() {
@@ -1634,7 +1634,9 @@ impl<G: NodeGenerics> ErasedNode for Node<G> {
             expert.swap_children(edge_index as usize, last_edge_index as usize);
             // if debug then Node.invariant ignore node;
         }
-        expert.remove_last_child_edge_exn();
+        let popped_edge = expert.pop_child_edge().unwrap();
+        debug_assert!(crate::dyn_thin_ptr_eq(&*popped_edge, dyn_edge));
+
         debug_assert!(self.is_stale());
         if self.is_necessary() {
             let state = self.state();

--- a/src/node.rs
+++ b/src/node.rs
@@ -543,7 +543,7 @@ impl<G: NodeGenerics> ParentNodeDyn for Node<G> {
                 let pci = self.parent_child_indices.borrow();
                 for (parent_index, parent) in self.parents.borrow().iter().enumerate() {
                     let child_index = pci.my_child_index_in_parent_at_index[parent_index];
-                    parent.child_changed(self, child_index, self_old);
+                    parent.child_changed(self, child_index, self_old)?;
                 }
             }
             _ => {}

--- a/src/public.rs
+++ b/src/public.rs
@@ -170,7 +170,7 @@ impl<T: Value> PartialEq for Var<T> {
     }
 }
 
-impl<T: Value> Deref for crate::Var<T> {
+impl<T: Value> Deref for Var<T> {
     type Target = Incr<T>;
     fn deref(&self) -> &Self::Target {
         &self.watch
@@ -531,6 +531,20 @@ impl Sub for Stats {
 /// so may as well accept Var anywhere we accept Incr.
 pub trait IntoIncr<T> {
     fn into_incr(self) -> Incr<T>;
+}
+
+impl<T: Value> AsRef<Incr<T>> for Var<T> {
+    #[inline]
+    fn as_ref(&self) -> &Incr<T> {
+        self.deref()
+    }
+}
+
+impl<T: Value> AsRef<Incr<T>> for Incr<T> {
+    #[inline]
+    fn as_ref(&self) -> &Incr<T> {
+        &self
+    }
 }
 
 impl<T> IntoIncr<T> for Incr<T> {

--- a/src/public.rs
+++ b/src/public.rs
@@ -121,7 +121,9 @@ impl<T: Value> Observer<T> {
     }
 
     pub fn disallow_future_use(&self) {
-        let Some(state) = self.internal.incr_state() else { return };
+        let Some(state) = self.internal.incr_state() else {
+            return;
+        };
         self.internal.disallow_future_use(&state);
     }
 }

--- a/src/public.rs
+++ b/src/public.rs
@@ -120,6 +120,13 @@ impl<T: Value> Observer<T> {
         super::node::save_dot_to_file(&mut core::iter::once(node), named).unwrap();
     }
 
+    pub fn save_dot_to_string(&self) -> String {
+        let node = self.internal.observing_erased();
+        let mut buf = String::new();
+        super::node::save_dot(&mut buf, &mut core::iter::once(node)).unwrap();
+        buf
+    }
+
     pub fn disallow_future_use(&self) {
         let Some(state) = self.internal.incr_state() else {
             return;
@@ -458,6 +465,10 @@ impl WeakState {
 
     pub fn save_dot_to_file(&self, named: &str) {
         self.inner.upgrade().unwrap().save_dot_to_file(named)
+    }
+
+    pub fn save_dot_to_string(&self) -> String {
+        self.inner.upgrade().unwrap().save_dot_to_string()
     }
 
     pub fn unsubscribe(&self, token: SubscriptionToken) {

--- a/src/scope.rs
+++ b/src/scope.rs
@@ -22,7 +22,9 @@ impl fmt::Debug for Scope {
         match self {
             Scope::Top => write!(f, "Scope::Top"),
             Scope::Bind(bind) => {
-                let Some(bind) = bind.upgrade() else { return write!(f, "Scope::Bind(weak, deallocated)") };
+                let Some(bind) = bind.upgrade() else {
+                    return write!(f, "Scope::Bind(weak, deallocated)");
+                };
                 write!(f, "Scope::Bind({:?})", bind.id())
             }
         }

--- a/src/state.rs
+++ b/src/state.rs
@@ -455,6 +455,13 @@ impl State {
         let mut all_observed = observers.iter().map(|(_id, o)| o.observing_erased());
         super::node::save_dot_to_file(&mut all_observed, named).unwrap();
     }
+    pub(crate) fn save_dot_to_string(&self) -> String {
+        let observers = self.all_observers.borrow();
+        let mut all_observed = observers.iter().map(|(_id, o)| o.observing_erased());
+        let mut buf = String::new();
+        super::node::save_dot(&mut buf, &mut all_observed).unwrap();
+        buf
+    }
 
     #[tracing::instrument]
     pub(crate) fn destroy(&self) {

--- a/src/state.rs
+++ b/src/state.rs
@@ -253,7 +253,9 @@ impl State {
     fn unlink_disallowed_observers(&self) {
         let mut disallowed = self.disallowed_observers.borrow_mut();
         for obs_weak in disallowed.drain(..) {
-            let Some(obs) = obs_weak.upgrade() else { continue };
+            let Some(obs) = obs_weak.upgrade() else {
+                continue;
+            };
             debug_assert_eq!(obs.state().get(), ObserverState::Disallowed);
             obs.state().set(ObserverState::Unlinked);
             // get a strong ref to the node, before we drop its owning InternalObserver
@@ -288,9 +290,7 @@ impl State {
         tracing::info_span!("set_during_stabilisation").in_scope(|| {
             let mut stack = self.set_during_stabilisation.borrow_mut();
             while let Some(var) = stack.pop() {
-                let Some(var) = var.upgrade() else {
-                    continue
-                };
+                let Some(var) = var.upgrade() else { continue };
                 tracing::debug!("set_during_stabilisation: found var with {:?}", var.id());
                 var.set_var_stabilise_end();
             }
@@ -304,9 +304,7 @@ impl State {
         tracing::info_span!("dead_vars").in_scope(|| {
             let mut stack = self.dead_vars.borrow_mut();
             for var in stack.drain(..) {
-                let Some(var) = var.upgrade() else {
-                    continue
-                };
+                let Some(var) = var.upgrade() else { continue };
                 tracing::debug!("dead_vars: found var with {:?}", var.id());
                 var.break_rc_cycle();
             }

--- a/src/state/expert.rs
+++ b/src/state/expert.rs
@@ -1,5 +1,3 @@
-use std::any::Any;
-
 use super::*;
 use crate::kind;
 use crate::node::Incremental;
@@ -78,10 +76,6 @@ pub(crate) fn add_dependency(node: &NodeRef, edge: PackedEdge) {
     node.expert_add_dependency(edge);
 }
 
-pub(crate) fn remove_dependency<T>(
-    node: &dyn Incremental<T>,
-    packed_edge: &dyn IsEdge,
-    edge: &dyn Any,
-) {
-    node.expert_remove_dependency(packed_edge, edge);
+pub(crate) fn remove_dependency<T>(node: &dyn Incremental<T>, dyn_edge: &dyn IsEdge) {
+    node.expert_remove_dependency(dyn_edge);
 }

--- a/src/state/expert.rs
+++ b/src/state/expert.rs
@@ -4,14 +4,13 @@ use crate::node::Incremental;
 use crate::WeakIncr;
 use kind::expert::{IsEdge, PackedEdge};
 
-pub(crate) fn create<T, C, F, O>(state: &State, recompute: F, on_observability_change: O) -> Incr<T>
+pub(crate) fn create<T, F, O>(state: &State, recompute: F, on_observability_change: O) -> Incr<T>
 where
     T: Value,
-    C: Value,
     F: FnMut() -> T + 'static,
     O: FnMut(bool) + 'static,
 {
-    let node = Node::<kind::ExpertNode<T, C, F, O>>::create_rc(
+    let node = Node::<kind::ExpertNode<T, F, O>>::create_rc(
         state.weak(),
         state.current_scope(),
         Kind::Expert(kind::ExpertNode::new_obs(
@@ -30,14 +29,13 @@ where
     Incr { node }
 }
 
-pub(crate) fn create_cyclic<T, C, Cyclic, F, O>(
+pub(crate) fn create_cyclic<T, Cyclic, F, O>(
     state: &State,
     cyclic: Cyclic,
     on_observability_change: O,
 ) -> Incr<T>
 where
     T: Value,
-    C: Value,
     Cyclic: FnOnce(WeakIncr<T>) -> F,
     F: FnMut() -> T + 'static,
     O: FnMut(bool) + 'static,
@@ -45,7 +43,7 @@ where
     let node = Rc::<Node<_>>::new_cyclic(|weak| {
         let weak_incr = WeakIncr(weak.clone());
         let recompute = cyclic(weak_incr);
-        let mut node = Node::<kind::ExpertNode<T, C, F, O>>::create(
+        let mut node = Node::<kind::ExpertNode<T, F, O>>::create(
             state.weak(),
             state.current_scope(),
             Kind::Expert(kind::ExpertNode::new_obs(

--- a/src/syntax.rs
+++ b/src/syntax.rs
@@ -7,30 +7,59 @@ use super::Value;
 /// Produced by the syntax `i1 % i2` for two `Incr`s.
 pub struct MapBuilder2<I1, I2>(Incr<I1>, Incr<I2>);
 /// Produced by the syntax `i1 % i2 % i3` for three `Incr`s.
-pub struct MapBuilder3<I1, I2, I3>(Incr<I1>, Incr<I2>, Incr<I3>);
 impl<I1, I2> Rem<Incr<I2>> for Incr<I1> {
     type Output = MapBuilder2<I1, I2>;
     fn rem(self, rhs: Incr<I2>) -> Self::Output {
         MapBuilder2(self, rhs)
     }
 }
+
+macro_rules! map_builder {
+    (@inner $n:ident<$($upto_i:ident),+ > => $n_plus_1:ident<.., $i_plus_1:ident>) => {
+        pub struct $n_plus_1<$($upto_i,)+ $i_plus_1>($(Incr<$upto_i>,)+ Incr<$i_plus_1>);
+
+        impl<$($upto_i,)+ $i_plus_1> Rem<Incr<$i_plus_1>> for $n<$($upto_i,)+> {
+            type Output = $n_plus_1<$($upto_i,)+ $i_plus_1>;
+            fn rem(self, rhs: Incr<$i_plus_1>) -> Self::Output {
+                $n_plus_1(self.0, self.1, rhs)
+            }
+        }
+        impl<$($upto_i,)+ $i_plus_1> Rem<&Incr<$i_plus_1>> for $n<$($upto_i,)+> {
+            type Output = $n_plus_1<$($upto_i,)+ $i_plus_1>;
+            fn rem(self, rhs: &Incr<$i_plus_1>) -> Self::Output {
+                $n_plus_1(self.0, self.1, rhs.clone())
+            }
+        }
+    };
+
+    {
+        [
+            $n:ident<$($upto_i:ident),+>,
+        ]
+    } => {
+    };
+    {
+        [
+            $n:ident<$($upto_i:ident),+>,
+            $n_plus_1:ident<.., $i_plus_1:ident>,
+            $($rest:tt)*
+        ]
+    } => {
+        map_builder!(@inner $n<$($upto_i),+> => $n_plus_1<.., $i_plus_1>);
+        map_builder!([$n_plus_1<$($upto_i,)+ $i_plus_1>, $($rest)*]);
+    };
+}
+
+map_builder!([
+     MapBuilder2<I1, I2>,
+     MapBuilder3<.., I3>,
+     // MapBuilder4<.., I4>,
+]);
+
 impl<I1, I2> Rem<&Incr<I2>> for &Incr<I1> {
     type Output = MapBuilder2<I1, I2>;
     fn rem(self, rhs: &Incr<I2>) -> Self::Output {
         MapBuilder2(self.clone(), rhs.clone())
-    }
-}
-
-impl<I1, I2, I3> Rem<Incr<I3>> for MapBuilder2<I1, I2> {
-    type Output = MapBuilder3<I1, I2, I3>;
-    fn rem(self, rhs: Incr<I3>) -> Self::Output {
-        MapBuilder3(self.0, self.1, rhs)
-    }
-}
-impl<I1, I2, I3> Rem<&Incr<I3>> for MapBuilder2<I1, I2> {
-    type Output = MapBuilder3<I1, I2, I3>;
-    fn rem(self, rhs: &Incr<I3>) -> Self::Output {
-        MapBuilder3(self.0, self.1, rhs.clone())
     }
 }
 

--- a/src/syntax.rs
+++ b/src/syntax.rs
@@ -4,57 +4,99 @@ use std::ops::Rem;
 use super::Incr;
 use super::Value;
 
-/// Produced by the syntax `i1 % i2` for two `Incr`s.
-pub struct MapBuilder2<I1, I2>(Incr<I1>, Incr<I2>);
-/// Produced by the syntax `i1 % i2 % i3` for three `Incr`s.
+macro_rules! map_builder {
+    (@def $(#[$attr:meta])* $n:ident<$vfirst:ident : $ifirst:ident, $($v:ident : $upto_i:ident),+ >::$map:ident) => {
+        $(#[$attr])*
+        pub struct $n<$ifirst, $($upto_i,)+>(Incr<$ifirst>, $(Incr<$upto_i>,)+);
+        impl<$ifirst: Value, $($upto_i: Value,)+> $n<$ifirst, $($upto_i),+> {
+            /// Maps the incrementals in the (i1 % i2 % ...) syntax all at once.
+            pub fn map<R: Value>(&self, f: impl FnMut(&$ifirst, $(&$upto_i),+) -> R + 'static) -> Incr<R> {
+                let Self($vfirst, $($v),+) = self;
+                $vfirst.$map($($v),+, f)
+            }
+            /// Zips the incrementals in the (i1 % i2 % ...) syntax into an `Incr<(I1, I2, ...)>`.
+            pub fn zip(&self) -> Incr<($ifirst, $($upto_i),+)> {
+                let Self($vfirst, $($v),+) = self;
+                $vfirst.$map($($v),+, |$vfirst, $($v),+| ($vfirst.clone(), $($v.clone()),+))
+            }
+        }
+    };
+
+
+    (@def_rem $n:ident<$($v:ident : $upto_i:ident),+ >
+              => $(#[$attr:meta])* $n_plus_1:ident<.., $v_plus_1:ident: $i_plus_1:ident>::$map_n_plus_1:ident) => {
+        map_builder!(@def $(#[$attr])* $n_plus_1<$($v: $upto_i,)+ $v_plus_1: $i_plus_1>::$map_n_plus_1);
+        impl<$($upto_i,)+ $i_plus_1> Rem<Incr<$i_plus_1>> for $n<$($upto_i,)+> {
+            type Output = $n_plus_1<$($upto_i,)+ $i_plus_1>;
+            fn rem(self, rhs: Incr<$i_plus_1>) -> Self::Output {
+                let Self($($v),+) = self;
+                $n_plus_1($($v,)+ rhs)
+            }
+        }
+        impl<$($upto_i,)+ $i_plus_1> Rem<&Incr<$i_plus_1>> for $n<$($upto_i,)+> {
+            type Output = $n_plus_1<$($upto_i,)+ $i_plus_1>;
+            fn rem(self, rhs: &Incr<$i_plus_1>) -> Self::Output {
+                let Self($($v),+) = self;
+                $n_plus_1($($v,)+ rhs.clone())
+            }
+        }
+    };
+
+    {
+        [
+            @rest
+            $n:ident<$($v:ident: $upto_i:ident),+>::$map_n:ident,
+        ]
+    } => {
+    };
+    {
+        [
+            @rest
+            $n:ident<$($v:ident: $upto_i:ident),+>::$map_n:ident,
+            $(#[$attr:meta])* $n_plus_1:ident<.., $v_plus_1:ident: $i_plus_1:ident>::$map_n_plus_1:ident,
+            $($rest:tt)*
+        ]
+    } => {
+        map_builder!(@def_rem $n<$($v: $upto_i),+> => $(#[$attr])* $n_plus_1<.., $v_plus_1: $i_plus_1>::$map_n_plus_1);
+        map_builder!([
+             @rest
+             $n_plus_1<$($v: $upto_i,)+ $v_plus_1: $i_plus_1>::$map_n_plus_1,
+             $($rest)*
+        ]);
+    };
+    {
+        [
+            $(#[$attr:meta])*
+            $n:ident<$($v:ident: $upto_i:ident),+>::$map:ident,
+            $($rest:tt)*
+        ]
+    } => {
+        map_builder!(@def $(#[$attr])* $n<$($v: $upto_i),+>::$map);
+        map_builder!([@rest $n<$($v: $upto_i),+>::$map, $($rest)*]);
+    };
+}
+
+map_builder!([
+    /// Produced by the syntax `i1 % i2` for two `Incr`s.
+    MapBuilder2<i1: I1, i2: I2>::map2,
+    /// Produced by the syntax `i1 % i2 % i3` for 3 `Incr`s.
+    MapBuilder3<.., i3: I3>::map3,
+    /// Produced by the syntax `i1 % i2 % i3 % i4` for 4 `Incr`s.
+    MapBuilder4<.., i4: I4>::map4,
+    /// Produced by the syntax `i1 % i2 % i3 % i4 % i5` for 5 `Incr`s.
+    MapBuilder5<.., i5: I5>::map5,
+    /// Produced by the syntax `i1 % i2 % i3 % i4 % i5 % i6` for 6 `Incr`s.
+    MapBuilder6<.., i6: I6>::map6,
+]);
+
+// Base case
+
 impl<I1, I2> Rem<Incr<I2>> for Incr<I1> {
     type Output = MapBuilder2<I1, I2>;
     fn rem(self, rhs: Incr<I2>) -> Self::Output {
         MapBuilder2(self, rhs)
     }
 }
-
-macro_rules! map_builder {
-    (@inner $n:ident<$($upto_i:ident),+ > => $n_plus_1:ident<.., $i_plus_1:ident>) => {
-        pub struct $n_plus_1<$($upto_i,)+ $i_plus_1>($(Incr<$upto_i>,)+ Incr<$i_plus_1>);
-
-        impl<$($upto_i,)+ $i_plus_1> Rem<Incr<$i_plus_1>> for $n<$($upto_i,)+> {
-            type Output = $n_plus_1<$($upto_i,)+ $i_plus_1>;
-            fn rem(self, rhs: Incr<$i_plus_1>) -> Self::Output {
-                $n_plus_1(self.0, self.1, rhs)
-            }
-        }
-        impl<$($upto_i,)+ $i_plus_1> Rem<&Incr<$i_plus_1>> for $n<$($upto_i,)+> {
-            type Output = $n_plus_1<$($upto_i,)+ $i_plus_1>;
-            fn rem(self, rhs: &Incr<$i_plus_1>) -> Self::Output {
-                $n_plus_1(self.0, self.1, rhs.clone())
-            }
-        }
-    };
-
-    {
-        [
-            $n:ident<$($upto_i:ident),+>,
-        ]
-    } => {
-    };
-    {
-        [
-            $n:ident<$($upto_i:ident),+>,
-            $n_plus_1:ident<.., $i_plus_1:ident>,
-            $($rest:tt)*
-        ]
-    } => {
-        map_builder!(@inner $n<$($upto_i),+> => $n_plus_1<.., $i_plus_1>);
-        map_builder!([$n_plus_1<$($upto_i,)+ $i_plus_1>, $($rest)*]);
-    };
-}
-
-map_builder!([
-     MapBuilder2<I1, I2>,
-     MapBuilder3<.., I3>,
-     // MapBuilder4<.., I4>,
-]);
 
 impl<I1, I2> Rem<&Incr<I2>> for &Incr<I1> {
     type Output = MapBuilder2<I1, I2>;
@@ -63,38 +105,22 @@ impl<I1, I2> Rem<&Incr<I2>> for &Incr<I1> {
     }
 }
 
-impl<I1: Value, I2: Value> MapBuilder2<I1, I2> {
-    pub fn map<R: Value>(&self, f: impl FnMut(&I1, &I2) -> R + 'static) -> Incr<R> {
-        let Self(i1, i2) = self;
-        i1.map2(i2, f)
-    }
-    pub fn zip(&self) -> Incr<(I1, I2)> {
-        let Self(i1, i2) = self;
-        i1.zip(i2)
-    }
-}
-
-impl<I1: Value, I2: Value, I3: Value> MapBuilder3<I1, I2, I3> {
-    pub fn map<R: Value>(&self, f: impl FnMut(&I1, &I2, &I3) -> R + 'static) -> Incr<R> {
-        let Self(i1, i2, i3) = self;
-        i1.map3(i2, i3, f)
-    }
-    pub fn zip(&self) -> Incr<(I1, I2, I3)> {
-        let Self(i1, i2, i3) = self;
-        i1.map3(i2, i3, |a, b, c| (a.clone(), b.clone(), c.clone()))
-    }
-}
-
-// TODO: implement MapBuilder4 and beyond
-
 #[test]
 fn test_syntax() {
     let incr = crate::IncrState::new();
     let i1 = incr.constant(5);
     let i2 = incr.constant(10);
     let i3 = incr.constant(9);
-    let out = (i1 % i2 % i3).map(|&a, &b, &c| a * b * c);
+    let out = (&i1 % &i2 % &i3).map(|&a, &b, &c| a * b * c);
     let obs = out.observe();
     incr.stabilise();
     assert_eq!(obs.try_get_value(), Ok(450));
+
+    let i4 = incr.constant(1);
+    let i5 = incr.constant(1);
+    let i6 = incr.constant(1);
+    let _4 = (&i1 % &i2 % &i3 % &i4).map(|_, _, _, _| 0);
+    let _5 = (&i1 % &i2 % &i3 % &i4 % &i5).map(|_, _, _, _, _| 0);
+    let _6 = (&i1 % &i2 % &i3 % &i4 % &i5 % &i6).map(|_, _, _, _, _, _| 0);
+    let _6_owned = (i1 % i2 % i3 % i4 % i5 % i6).map(|_, _, _, _, _, _| 0);
 }

--- a/src/syntax.rs
+++ b/src/syntax.rs
@@ -39,12 +39,20 @@ impl<I1: Value, I2: Value> MapBuilder2<I1, I2> {
         let Self(i1, i2) = self;
         i1.map2(i2, f)
     }
+    pub fn zip(&self) -> Incr<(I1, I2)> {
+        let Self(i1, i2) = self;
+        i1.zip(i2)
+    }
 }
 
 impl<I1: Value, I2: Value, I3: Value> MapBuilder3<I1, I2, I3> {
     pub fn map<R: Value>(&self, f: impl FnMut(&I1, &I2, &I3) -> R + 'static) -> Incr<R> {
         let Self(i1, i2, i3) = self;
         i1.map3(i2, i3, f)
+    }
+    pub fn zip(&self) -> Incr<(I1, I2, I3)> {
+        let Self(i1, i2, i3) = self;
+        i1.map3(i2, i3, |a, b, c| (a.clone(), b.clone(), c.clone()))
     }
 }
 

--- a/src/syntax.rs
+++ b/src/syntax.rs
@@ -14,11 +14,23 @@ impl<I1, I2> Rem<Incr<I2>> for Incr<I1> {
         MapBuilder2(self, rhs)
     }
 }
+impl<I1, I2> Rem<&Incr<I2>> for &Incr<I1> {
+    type Output = MapBuilder2<I1, I2>;
+    fn rem(self, rhs: &Incr<I2>) -> Self::Output {
+        MapBuilder2(self.clone(), rhs.clone())
+    }
+}
 
 impl<I1, I2, I3> Rem<Incr<I3>> for MapBuilder2<I1, I2> {
     type Output = MapBuilder3<I1, I2, I3>;
     fn rem(self, rhs: Incr<I3>) -> Self::Output {
         MapBuilder3(self.0, self.1, rhs)
+    }
+}
+impl<I1, I2, I3> Rem<&Incr<I3>> for MapBuilder2<I1, I2> {
+    type Output = MapBuilder3<I1, I2, I3>;
+    fn rem(self, rhs: &Incr<I3>) -> Self::Output {
+        MapBuilder3(self.0, self.1, rhs.clone())
     }
 }
 
@@ -30,13 +42,13 @@ impl<I1: Value, I2: Value> MapBuilder2<I1, I2> {
 }
 
 impl<I1: Value, I2: Value, I3: Value> MapBuilder3<I1, I2, I3> {
-    pub fn map<R: Value>(&self, mut f: impl FnMut(&I1, &I2, &I3) -> R + 'static) -> Incr<R> {
+    pub fn map<R: Value>(&self, f: impl FnMut(&I1, &I2, &I3) -> R + 'static) -> Incr<R> {
         let Self(i1, i2, i3) = self;
-        // TODO: implement map3 and beyond
-        let one_two: Incr<(I1, I2)> = i1.map2(i2, |a, b| (a.clone(), b.clone()));
-        one_two.map2(i3, move |(a, b), c| f(a, b, c))
+        i1.map3(i2, i3, f)
     }
 }
+
+// TODO: implement MapBuilder4 and beyond
 
 #[test]
 fn test_syntax() {

--- a/src/var.rs
+++ b/src/var.rs
@@ -1,4 +1,4 @@
-use crate::Value;
+use crate::{node_generics_default, Value};
 #[cfg(test)]
 use test_log::test;
 
@@ -16,19 +16,10 @@ use std::rc::{Rc, Weak};
 pub(crate) struct VarGenerics<T: Value>(std::marker::PhantomData<T>);
 impl<R: Value> NodeGenerics for VarGenerics<R> {
     type R = R;
-    type BindLhs = ();
-    type BindRhs = ();
-    type I1 = ();
-    type I2 = ();
-    type F1 = fn(&Self::I1) -> Self::R;
-    type F2 = fn(&Self::I1, &Self::I2) -> Self::R;
-    type B1 = fn(&Self::BindLhs) -> Incr<Self::BindRhs>;
-    type Fold = fn(Self::R, &Self::I1) -> Self::R;
-    type Update = fn(Self::R, &Self::I1, &Self::I1) -> Self::R;
-    type WithOld = fn(Option<Self::R>, &Self::I1) -> (Self::R, bool);
-    type FRef = fn(&Self::I1) -> &Self::R;
-    type Recompute = fn() -> Self::R;
-    type ObsChange = fn(bool);
+    node_generics_default! { I1, I2, I3, I4, I5 }
+    node_generics_default! { F1, F2, F3, F4, F5 }
+    node_generics_default! { B1, BindLhs, BindRhs }
+    node_generics_default! { Fold, Update, WithOld, FRef, Recompute, ObsChange }
 }
 
 // For the delayed variable set list (set_during_stabilisation).

--- a/src/var.rs
+++ b/src/var.rs
@@ -16,8 +16,8 @@ use std::rc::{Rc, Weak};
 pub(crate) struct VarGenerics<T: Value>(std::marker::PhantomData<T>);
 impl<R: Value> NodeGenerics for VarGenerics<R> {
     type R = R;
-    node_generics_default! { I1, I2, I3, I4, I5 }
-    node_generics_default! { F1, F2, F3, F4, F5 }
+    node_generics_default! { I1, I2, I3, I4, I5, I6 }
+    node_generics_default! { F1, F2, F3, F4, F5, F6 }
     node_generics_default! { B1, BindLhs, BindRhs }
     node_generics_default! { Fold, Update, WithOld, FRef, Recompute, ObsChange }
 }

--- a/src/var.rs
+++ b/src/var.rs
@@ -201,7 +201,10 @@ impl<T: Value> Var<T> {
 
     fn did_set_var_while_not_stabilising(&self) {
         let Some(watch) = self.node.borrow().clone() else {
-            panic!("uninitialised var or abandoned watch node (had {:?})", self.node_id)
+            panic!(
+                "uninitialised var or abandoned watch node (had {:?})",
+                self.node_id
+            )
         };
         let t = self.state.upgrade().unwrap();
         t.num_var_sets.increment();

--- a/tests/basic.rs
+++ b/tests/basic.rs
@@ -1142,3 +1142,19 @@ fn map345() {
     assert_eq!(quad.value(), 109);
     assert_eq!(five.value(), 309);
 }
+
+#[test]
+fn map345_ref() {
+    let incr = IncrState::new();
+    let i1 = incr.var(3);
+    let i2 = incr.var(5);
+    let i3 = incr.var(7);
+    let triple = i1.map3(&i2, &i3, |a, b, c| (a * b, *c));
+    let trip = triple.observe();
+    incr.stabilise();
+    assert_eq!(trip.value(), (15, 7));
+    let by_ref = triple.map_ref(|(ab, _)| ab);
+    let obs = by_ref.observe();
+    incr.stabilise();
+    assert_eq!(obs.value(), 15);
+}

--- a/tests/basic.rs
+++ b/tests/basic.rs
@@ -1123,7 +1123,7 @@ fn test_duplicate_incrstate_drop() {
 }
 
 #[test]
-fn map345() {
+fn map3456() {
     let incr = IncrState::new();
     let i1 = incr.var(3);
     let i2 = incr.var(5);
@@ -1137,19 +1137,26 @@ fn map345() {
     assert_eq!(trip.value(), 24);
     let i4 = incr.var(100);
     let i5 = incr.var(200);
+    let i6 = incr.var(300);
     let quadruple = i1.map4(&i2, &i3, &i4, |a, b, c, d| a * b + c + d);
     let quad = quadruple.observe();
     let quintuple = i1.map5(&i2, &i3, &i4, &i5, |a, b, c, d, e| a * b + c + d + e);
     let five = quintuple.observe();
+    let sextuple = i1.map6(&i2, &i3, &i4, &i5, &i6, |a, b, c, d, e, f| {
+        a * b + c + d + e + f
+    });
+    let six = sextuple.observe();
     incr.stabilise();
     assert_eq!(trip.value(), 24);
     assert_eq!(quad.value(), 124);
     assert_eq!(five.value(), 324);
+    assert_eq!(six.value(), 624);
     i1.set(0);
     incr.stabilise();
     assert_eq!(trip.value(), 9);
     assert_eq!(quad.value(), 109);
     assert_eq!(five.value(), 309);
+    assert_eq!(six.value(), 609);
 }
 
 #[test]

--- a/tests/basic.rs
+++ b/tests/basic.rs
@@ -1112,3 +1112,33 @@ fn test_duplicate_incrstate_drop() {
     drop(obs);
     drop(incr);
 }
+
+#[test]
+fn map345() {
+    let incr = IncrState::new();
+    let i1 = incr.var(3);
+    let i2 = incr.var(5);
+    let i3 = incr.var(7);
+    let triple = i1.map3(&i2, &i3, |a, b, c| a * b + c);
+    let trip = triple.observe();
+    incr.stabilise();
+    assert_eq!(trip.value(), 22);
+    i3.set(9);
+    incr.stabilise();
+    assert_eq!(trip.value(), 24);
+    let i4 = incr.var(100);
+    let i5 = incr.var(200);
+    let quadruple = i1.map4(&i2, &i3, &i4, |a, b, c, d| a * b + c + d);
+    let quad = quadruple.observe();
+    let quintuple = i1.map5(&i2, &i3, &i4, &i5, |a, b, c, d, e| a * b + c + d + e);
+    let five = quintuple.observe();
+    incr.stabilise();
+    assert_eq!(trip.value(), 24);
+    assert_eq!(quad.value(), 124);
+    assert_eq!(five.value(), 324);
+    i1.set(0);
+    incr.stabilise();
+    assert_eq!(trip.value(), 9);
+    assert_eq!(quad.value(), 109);
+    assert_eq!(five.value(), 309);
+}

--- a/tests/basic.rs
+++ b/tests/basic.rs
@@ -267,12 +267,21 @@ fn observer_ugly() {
     // ok none of this is guaranteed to work but i'm just trying to break it
     lhs.set(false);
     unused.set(700);
-    assert_eq!(o2.try_get_value(), Ok(Err(ObserverError::CurrentlyStabilising)));
+    assert_eq!(
+        o2.try_get_value(),
+        Ok(Err(ObserverError::CurrentlyStabilising))
+    );
     incr.stabilise();
-    assert_eq!(o2.try_get_value(), Ok(Err(ObserverError::CurrentlyStabilising)));
+    assert_eq!(
+        o2.try_get_value(),
+        Ok(Err(ObserverError::CurrentlyStabilising))
+    );
     unrelated.set(99);
     incr.stabilise();
-    assert_eq!(o2.try_get_value(), Ok(Err(ObserverError::CurrentlyStabilising)));
+    assert_eq!(
+        o2.try_get_value(),
+        Ok(Err(ObserverError::CurrentlyStabilising))
+    );
 }
 
 #[test]

--- a/tests/expert.rs
+++ b/tests/expert.rs
@@ -12,7 +12,8 @@ fn join<T: Value>(incr: &Incr<Incr<T>>) -> Incr<T> {
         move || prev_rhs_.borrow().clone().unwrap().value_cloned()
     });
     let join_ = join.weak();
-    // TODO: should not need to create a map node for this.
+    // In order to schedule the dependency additions/deletions before the expert Node executes,
+    // we put this in a Map node (akin to BindLhsChange).
     let lhs_change = incr.map(move |rhs| {
         let dep = join_.add_dependency(rhs);
         let mut prev_rhs_ = prev_rhs.borrow_mut();

--- a/tests/expert.rs
+++ b/tests/expert.rs
@@ -2,7 +2,7 @@ use std::{cell::RefCell, rc::Rc};
 
 use incremental::{expert::*, Incr, IncrState, Value};
 
-fn join<T: Value>(incr: Incr<Incr<T>>) -> Incr<T> {
+fn join<T: Value>(incr: &Incr<Incr<T>>) -> Incr<T> {
     let prev_rhs: Rc<RefCell<Option<Dependency<T>>>> = Rc::new(None.into());
     let state = incr.state();
     let join = Node::<T, T>::new(&state, {
@@ -10,6 +10,7 @@ fn join<T: Value>(incr: Incr<Incr<T>>) -> Incr<T> {
         move || prev_rhs_.borrow().clone().unwrap().value_cloned()
     });
     let join_ = join.weak();
+    // TODO: should not need to create a map node for this.
     let lhs_change = incr.map(move |rhs| {
         let dep = join_.add_dependency(rhs);
         let mut prev_rhs_ = prev_rhs.borrow_mut();
@@ -27,7 +28,7 @@ fn test_join() {
     let incr = IncrState::new();
     let inner = incr.var(10i32);
     let outer = incr.var(inner.watch());
-    let joined = join(outer.watch());
+    let joined = join(&outer);
     let o = joined.observe();
     incr.stabilise();
     assert_eq!(o.try_get_value(), Ok(10));
@@ -59,4 +60,21 @@ fn bind<T: Value, R: Value>(incr: Incr<T>, mut f: impl FnMut(&T) -> Incr<R> + 's
     });
     join.add_dependency_unit(&lhs_change);
     join.watch()
+}
+
+#[test]
+fn map345_expert() {
+    let incr = IncrState::new();
+    let i1 = incr.var(3);
+    let i2 = incr.var(5);
+    let i3 = incr.var(7);
+    let triple = i1.map3(&i2, &i3, |a, b, c| (a * b, *c));
+
+    // now have an expert node add a dependency on triple
+    let outer = incr.var(triple.clone());
+    let joined = join(&outer);
+
+    let j = joined.observe();
+    incr.stabilise();
+    assert_eq!(j.value(), (15, 7));
 }

--- a/tests/expert.rs
+++ b/tests/expert.rs
@@ -1,4 +1,6 @@
 use std::{cell::RefCell, rc::Rc};
+// RUST_LOG_SPAN_EVENTS=enter,exit
+use test_log::test;
 
 use incremental::{expert::*, Incr, IncrState, Value};
 


### PR DESCRIPTION
```rust
let (i1, i2, i3, i4) = ...;

let mapped_4 = i1.map4(&i2, &i3, &i4, |i1, i2, i3, i4| { ... });

// or use the fun % syntax that's easier to read, runs through rustfmt better,
// and doesn't require counting 3 parameters and writing `map4`.
let mapped_4 = (&i1 % &i2 % &i3 % &i4).map(|i1, i2, i3, i4| { ... });
```

This is supported up to map6. I will probably add more later, and it still lacks a `mapN` (where all the inputs are the same type).

This is a breaking change, because I also changed the API for expert node dependencies, so that you are not limited to two types (`T` and `()`) for all of the dependencies for an expert node. Rather, any old T: Value can be put in a dependency via `Node::add_dependency<T>()`, you'll get a `Dependency<T>` back, and you can also make `Dependency<T2>` from the same node. We will use `dyn` internally. This was better as a breaking change because `Node` used to be `Node<T>`, and now that T is meaningless.