### PR TITLE
PartialEq implementations on `Observer`, `IncrState`, `WeakState` using Rc::ptr_eq

### DIFF
--- a/src/public.rs
+++ b/src/public.rs
@@ -42,6 +42,7 @@ pub enum Update<T> {
     Invalidated,
 }
 impl<T> Update<T> {
+    #[inline]
     pub fn value(self) -> Option<T> {
         match self {
             Self::Initialised(t) => Some(t),
@@ -51,6 +52,7 @@ impl<T> Update<T> {
     }
 }
 impl<T> Update<&T> {
+    #[inline]
     pub fn cloned(&self) -> Update<T>
     where
         T: Clone,
@@ -64,6 +66,7 @@ impl<T> Update<&T> {
 }
 
 impl<T: Value> Observer<T> {
+    #[inline]
     pub(crate) fn new(internal: Rc<InternalObserver<T>>) -> Self {
         Self {
             internal,
@@ -319,6 +322,7 @@ impl IncrState {
         Rc::ptr_eq(&self.inner, &other.inner)
     }
 
+    #[inline]
     pub fn weak(&self) -> WeakState {
         WeakState {
             inner: Rc::downgrade(&self.inner),
@@ -369,6 +373,7 @@ impl IncrState {
 
     /// Returns true if there is nothing to do. In particular, this allows you to
     /// find a fixed point in a computation that sets variables during stabilisation.
+    #[inline]
     pub fn is_stable(&self) -> bool {
         self.inner.is_stable()
     }
@@ -432,6 +437,7 @@ impl IncrState {
     /// Returns true if the current thread of execution is inside a stabilise call.
     /// Useful because [IncrState::stabilise] panics if you call
     /// stabilise recursively, so this helps avoid doing so.
+    #[inline]
     pub fn is_stabilising(&self) -> bool {
         self.inner.is_stabilising()
     }
@@ -514,12 +520,15 @@ impl PartialEq for WeakState {
 }
 
 impl WeakState {
+    #[inline]
     pub fn ptr_eq(&self, other: &Self) -> bool {
         self.inner.ptr_eq(&other.inner)
     }
+    #[inline]
     pub fn strong_count(&self) -> usize {
         self.inner.strong_count()
     }
+    #[inline]
     pub fn weak_count(&self) -> usize {
         self.inner.weak_count()
     }
@@ -536,6 +545,7 @@ impl WeakState {
     /// an IncrState, which is capable of calling `stabilise` and panicking because you can't
     /// stabilise recursively. So it may be best to keep it as `WeakState`, wherever possible.
     ///
+    #[inline]
     pub fn upgrade(&self) -> Option<IncrState> {
         Some(IncrState {
             inner: self.upgrade_inner()?,

--- a/src/public.rs
+++ b/src/public.rs
@@ -27,6 +27,14 @@ pub struct Observer<T: Value> {
     sentinel: Rc<()>,
 }
 
+/// Implemented as pointer equality, like [Rc::ptr_eq].
+impl<T: Value> PartialEq for Observer<T> {
+    #[inline]
+    fn eq(&self, other: &Self) -> bool {
+        Rc::ptr_eq(&self.internal, &other.internal)
+    }
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum Update<T> {
     Initialised(T),
@@ -288,6 +296,14 @@ impl Default for IncrState {
     }
 }
 
+/// Implemented as pointer equality, like [Rc::ptr_eq].
+impl PartialEq for IncrState {
+    #[inline]
+    fn eq(&self, other: &Self) -> bool {
+        self.ptr_eq(other)
+    }
+}
+
 impl IncrState {
     pub fn new() -> Self {
         let inner = State::new();
@@ -296,6 +312,11 @@ impl IncrState {
     pub fn new_with_height(max_height: usize) -> Self {
         let inner = State::new_with_height(max_height);
         Self { inner }
+    }
+
+    #[inline]
+    pub fn ptr_eq(&self, other: &Self) -> bool {
+        Rc::ptr_eq(&self.inner, &other.inner)
     }
 
     pub fn weak(&self) -> WeakState {
@@ -483,6 +504,15 @@ impl IncrState {
 pub struct WeakState {
     pub(crate) inner: Weak<State>,
 }
+
+/// Implemented as pointer equality, like [Weak::ptr_eq].
+impl PartialEq for WeakState {
+    #[inline]
+    fn eq(&self, other: &Self) -> bool {
+        self.ptr_eq(other)
+    }
+}
+
 impl WeakState {
     pub fn ptr_eq(&self, other: &Self) -> bool {
         self.inner.ptr_eq(&other.inner)


### PR DESCRIPTION
Turns out not having these was really annoying when using Incremental with `yew`. Yew needs everything to be PartialEq, and there was an obvious implementation we could use, but it wasn't done.