### PR TITLE
Add to crate metadata: repository URL, categories, and keywords.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,8 +3,11 @@ name = "incremental"
 version = "0.2.1"
 authors = ["Cormac Relf <web@cormacrelf.net>"]
 edition = "2021"
+categories = ["algorithms", "data-structures", "caching"]
 description = "incremental computations, based on Jane Street's incremental"
+keywords = ["incremental", "computation"]
 license = "MIT"
+repository = "https://github.com/cormacrelf/incremental-rs"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 


### PR DESCRIPTION
This PR adds a repository URL to the crate, so it will appear in the sidebar at https://crates.io/crates/incremental where users can easily find it and send PRs, report issues, and share issue workarounds.

Crates.io search is poor and relies on categories and keywords in crate metadata.  For example, [searching crates.io for "incremental computation"](https://crates.io/search?q=incremental%20computation) shows this crate on the second page of results.  This PR adds categories and keywords to make it appear on the first page.