### PR TITLE
Fix duplicate inputs causing BorrowMutError in remove_parent

### DIFF
--- a/src/incr.rs
+++ b/src/incr.rs
@@ -231,10 +231,6 @@ impl<T: Value> Incr<T> {
         R: Value,
         F: FnMut(&T, &T2) -> R + 'static,
     {
-        assert!(
-            !self.ptr_eq(&other),
-            "You cannot map2 an incremental with itself. We need to be able to borrow_mut both at the same time."
-        );
         let mapper = kind::Map2Node {
             one: self.clone().node,
             two: other.clone().node,

--- a/tests/basic.rs
+++ b/tests/basic.rs
@@ -1228,7 +1228,6 @@ fn var_bind_to_itself() {
 }
 
 #[test]
-#[should_panic = "cannot map2 an incremental with itself"]
 fn map2_itself() {
     let incr = IncrState::new();
     let var = incr.var(5i32);
@@ -1243,7 +1242,6 @@ fn map2_itself() {
 }
 
 #[test]
-#[should_panic = "cannot map2 an incremental with itself"]
 fn map2_itself_unobserved() {
     let incr = IncrState::new();
     let var = incr.var(5i32);
@@ -1331,5 +1329,30 @@ fn simultaneous_disallow_and_rebind() {
     drop(o);
     incr.stabilise();
     let _o2 = b1.observe();
+    incr.stabilise();
+}
+
+#[test]
+fn fold_duplicate_inputs() {
+    let incr = IncrState::new();
+    let constant = incr.constant(1);
+
+    let vec = vec![constant.clone(), constant];
+    let fold = incr.fold(vec, 0, |i, _| i + 1);
+    let obs = fold.observe();
+    incr.stabilise();
+    drop(obs);
+    incr.stabilise();
+}
+
+#[test]
+fn map_duplicate_inputs() {
+    let incr = IncrState::new();
+    let constant = incr.constant(1);
+
+    let combine = (constant.clone() % constant).map(|_, _| 5);
+    let obs = combine.observe();
+    incr.stabilise();
+    drop(obs);
     incr.stabilise();
 }

--- a/tests/expert.rs
+++ b/tests/expert.rs
@@ -145,3 +145,15 @@ fn test_zip2() {
     incr.stabilise();
     assert_eq!(o.value(), (3, 5));
 }
+
+#[test]
+fn expert_duplicate_inputs() {
+    let incr = IncrState::new();
+    let constant = incr.constant(3);
+    let z = manual_zip2(&constant, &constant);
+    let o = z.observe();
+    incr.stabilise();
+    assert_eq!(o.value(), (3, 3));
+    drop(o);
+    incr.stabilise();
+}


### PR DESCRIPTION
Implementing swap_remove while mutating with borrow_mut() is tricky.

Now you can map nodes with themselves, and fold over a list of incrementals with duplicates in them.