### PR TITLE
Fix expert mode

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ tracing-subscriber = { version = "0.3.16", default-features = false, features = 
   "smallvec",
   "tracing-log",
 ] }
-criterion = { version = "0.4.0", features = ["html_reports"] }
+criterion = { version = "0.5.1", features = ["html_reports"] }
 tracing = { version = "0.1.37", features = ["release_max_level_off"] }
 im-rc = { version = "15.1.0" }
 

--- a/benches/linear.rs
+++ b/benches/linear.rs
@@ -1,3 +1,4 @@
+use std::hint::black_box;
 use std::time::Instant;
 
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
@@ -104,7 +105,7 @@ fn bench_node(c: &mut Criterion, kind: SequenceKind, size: u64) {
             for _ in 0..iters {
                 var.update(|x| x + 1);
                 incr.stabilise();
-                drop(obs.value());
+                black_box(obs.value());
             }
             start.elapsed()
         })
@@ -116,7 +117,7 @@ fn bench_stabilise(c: &mut Criterion, kind: SequenceKind, size: u64) {
         let (_var, incr, obs, _recomputed) = setup(kind, size);
         b.iter(|| {
             incr.stabilise();
-            drop(obs.value());
+            black_box(obs.value());
         })
     });
 }

--- a/src/node.rs
+++ b/src/node.rs
@@ -756,6 +756,8 @@ pub(crate) trait ErasedNode: Debug {
     #[cfg(debug_assertions)]
     #[allow(unused)]
     fn assert_currently_running_node_is_parent(&self, name: &'static str);
+    #[cfg(debug_assertions)]
+    #[allow(unused)]
     fn has_child(&self, child: &WeakNode) -> bool;
     fn adjust_heights_bind_lhs_change(
         &self,
@@ -1401,6 +1403,7 @@ impl<G: NodeGenerics> ErasedNode for Node<G> {
         }
     }
 
+    #[cfg(debug_assertions)]
     fn has_child(&self, child: &WeakNode) -> bool {
         let Some(upgraded) = child.upgrade() else {
             return false;

--- a/src/node.rs
+++ b/src/node.rs
@@ -304,7 +304,7 @@ impl<G: NodeGenerics> Incremental<G::R> for Node<G> {
             pty = parent.kind_debug_ty(),
             chty = child.kind().map(|k| k.debug_ty()),
         );
-        debug_assert!(parent_ref.weak().ptr_eq(&child_parents[parent_index as usize].clone()));
+        debug_assert!(parent_ref.weak().ptr_eq(&child_parents[parent_index as usize]));
 
         // unlink last_parent_index & child_index
         //
@@ -510,9 +510,11 @@ impl<T: Value> ParentWeak<T> {
     }
     fn ptr_eq(&self, other: &Self) -> bool {
         match (self, other) {
-            (Self::Input1(a), Self::Input1(b)) => a.ptr_eq(b),
-            (Self::Input2(a), Self::Input2(b)) => a.ptr_eq(b),
-            (Self::Dynamic(a, ix_a), Self::Dynamic(b, ix_b)) => ix_a == ix_b && a.ptr_eq(b),
+            (Self::Input1(a), Self::Input1(b)) => crate::weak_thin_ptr_eq(a, b),
+            (Self::Input2(a), Self::Input2(b)) => crate::weak_thin_ptr_eq(a, b),
+            (Self::Dynamic(a, ix_a), Self::Dynamic(b, ix_b)) => {
+                ix_a == ix_b && crate::weak_thin_ptr_eq(a, b)
+            }
             _ => false,
         }
     }


### PR DESCRIPTION
https://github.com/cormacrelf/incremental-rs/pull/1 allowed for expert nodes to have more than one type of dependency. However these changes weren't tested enough, and the `shares_per_symbol` benchmark broke.

This restores expert node functionality.