### PR TITLE
add a nightly-only auto trait to prevent incremental nodes holding observers

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ im-rc = { version = "15.1.0" }
 
 [features]
 rust-analyzer = []
+nightly-incrsan = []
 
 [dependencies]
 refl = "0.2.1"

--- a/src/cutoff.rs
+++ b/src/cutoff.rs
@@ -1,3 +1,5 @@
+use crate::incrsan::NotObserver;
+
 #[derive(Clone)]
 #[non_exhaustive]
 pub enum Cutoff<T> {
@@ -8,13 +10,13 @@ pub enum Cutoff<T> {
     FnBoxed(Box<dyn CutoffClosure<T>>),
 }
 
-pub trait CutoffClosure<T>: FnMut(&T, &T) -> bool {
+pub trait CutoffClosure<T>: FnMut(&T, &T) -> bool + NotObserver {
     fn clone_box(&self) -> Box<dyn CutoffClosure<T>>;
 }
 
 impl<T, F> CutoffClosure<T> for F
 where
-    F: FnMut(&T, &T) -> bool + Clone + 'static,
+    F: FnMut(&T, &T) -> bool + Clone + 'static + NotObserver,
 {
     fn clone_box(&self) -> Box<dyn CutoffClosure<T>> {
         Box::new(self.clone())

--- a/src/incrsan.rs
+++ b/src/incrsan.rs
@@ -1,0 +1,75 @@
+//! Sanitisers for using incremental correctly.
+//!
+//! These are enabled by the `nightly-incrsan` feature flag, which requires a nightly compiler.
+//! They primarily work through auto-traits, which can be a bit of a pain since incremental code
+//! often interfaces with other code exposing `Box<dyn Fn()>`-like APIs. So it is not enabled by
+//! default.
+//!
+//! You can opt-in by:
+//!
+//! - enabling the `nightly-incrsan` feature;
+//! - peppering around [`+ NotObserver`][NotObserver] bounds on things like `impl FnMut() -> ...`;
+//! - wrapping foreign types in [AssertNotObserver] when you are sure they do not contain observers
+
+// Rustc will parse things inside the cfg attribute even if the feature is not enabled.
+// But #[path = "..."] will help the compiler only parse one version of this code.
+//
+#[cfg_attr(feature = "nightly-incrsan", path = "incrsan/nightly.rs")]
+#[cfg_attr(not(feature = "nightly-incrsan"), path = "incrsan/stable.rs")]
+mod implementation;
+
+pub use implementation::*;
+
+/// A wrapper struct to assert that its contents are not observers, in the vein of
+/// [`std::panic::AssertUnwindSafe`].
+///
+/// Only does anything with the `nightly-incrsan` feature enabled.
+///
+/// This is good if you have a `Box<dyn Trait>` you want to use somewhere, where the trait is some
+/// foreign trait and you can't prove it to the compiler, but it doesn't have any observers in it.
+///
+/// For example:
+///
+/// ```
+/// use incremental::*;
+/// use incremental::incrsan::*;
+///
+/// let state = IncrState::new();
+/// let constant = state.constant(1);
+/// let not_observer: Box<dyn Fn()> = Box::new(|| println!("hello"));
+///
+/// // wrap in this to assert to the compiler it's ok, since you know what you put in the box
+/// let not_observer = AssertNotObserver(not_observer);
+///
+/// // now you can use it freely inside map nodes, observer.subscribe() callbacks, etc
+/// let map = constant.map(move |_| {
+///     not_observer(); // No longer a compiler error
+///     1234
+/// });
+/// ```
+#[repr(transparent)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct AssertNotObserver<T>(pub T);
+
+impl<T> std::ops::Deref for AssertNotObserver<T> {
+    type Target = T;
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl<T> std::ops::DerefMut for AssertNotObserver<T> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
+/// Let the compiler check for you that T does not contain an observer.
+///
+/// Useful if you're about to wrap in an AssertNotObserver, and then
+/// wrap in some kind of container that has no observers, that you know
+/// of, but you still want to check that the type you're putting in the
+/// container is `NotObserver`.
+pub fn check_not_observer<T: NotObserver>(value: T) -> T {
+    value
+}

--- a/src/incrsan/nightly.rs
+++ b/src/incrsan/nightly.rs
@@ -1,0 +1,28 @@
+///
+/// Nightly-only auto trait to prevent having an incremental node own an Observer, which is
+/// invalid use of the API and will panic when dropped.
+///
+/// ```compile_fail
+/// use incremental::*;
+///
+/// let state = IncrState::new();
+/// let constant = state.constant(1);
+/// let observer = constant.observe();
+/// let map = constant.map(move |_| {
+///     let _ = observer.value(); // invalid! will panic, so don't try!
+///     1234
+/// });
+/// ```
+///
+#[diagnostic::on_unimplemented(
+    message = "Type contains an incremental::Observer",
+    // {Self} expands to the thing that doesn't implement NotObserver, which is e.g.
+    // `Observer<i32>`.
+    label = "Contains {Self}, which is either an Observer or cannot be proven not to contain one.",
+    note = "Observers are the roots for garbage-collecting incremental nodes.\nThey hold incrementals, not the other way round.\nIf you need access to another incremental value in a map node, try map2.\nIf you know this type has no observers, you can use incremental::incrsan::AssertNotObserver.\n"
+)]
+pub auto trait NotObserver {}
+
+impl<T> !NotObserver for crate::public::Observer<T> {}
+
+impl<T> NotObserver for super::AssertNotObserver<T> {}

--- a/src/incrsan/stable.rs
+++ b/src/incrsan/stable.rs
@@ -1,0 +1,9 @@
+/// Inactive auto trait, as `nightly-incrsan` feature is not enabled.
+///
+/// Designed to prevent having an incremental node own an Observer, which is
+/// invalid use of the API and will panic when dropped.
+///
+/// This type is implemented for every T, which means it does not restrict anything.
+/// You should only have to deal with this trait if you enable the `nightly-incrsan` feature.
+pub trait NotObserver {}
+impl<T: ?Sized> NotObserver for T {}

--- a/src/internal_observer.rs
+++ b/src/internal_observer.rs
@@ -12,6 +12,7 @@ use std::{cell::Cell, rc::Weak};
 
 use super::{CellIncrement, Incr};
 use super::{NodeRef, Value};
+use crate::incrsan::NotObserver;
 
 use self::ObserverState::*;
 
@@ -43,7 +44,7 @@ pub(crate) struct InternalObserver<T> {
 pub(crate) type WeakObserver = Weak<dyn ErasedObserver>;
 pub(crate) type StrongObserver = Rc<dyn ErasedObserver>;
 
-pub(crate) trait ErasedObserver: Debug {
+pub(crate) trait ErasedObserver: Debug + NotObserver {
     fn id(&self) -> ObserverId;
     fn state(&self) -> &Cell<ObserverState>;
     fn observing_packed(&self) -> NodeRef;

--- a/src/kind.rs
+++ b/src/kind.rs
@@ -3,6 +3,7 @@ use std::rc::Rc;
 
 use super::node::Node;
 use super::var::Var;
+use crate::incrsan::NotObserver;
 use crate::{Incr, Value};
 
 #[macro_export]
@@ -51,7 +52,7 @@ pub(crate) use bind::*;
 pub(crate) use expert::ExpertNode;
 pub(crate) use map::*;
 
-pub(crate) trait NodeGenerics: 'static {
+pub(crate) trait NodeGenerics: 'static + NotObserver {
     type R: Value;
     type BindLhs: Value;
     type BindRhs: Value;
@@ -61,19 +62,20 @@ pub(crate) trait NodeGenerics: 'static {
     type I4: Value;
     type I5: Value;
     type I6: Value;
-    type F1: FnMut(&Self::I1) -> Self::R;
-    type FRef: Fn(&Self::I1) -> &Self::R;
-    type F2: FnMut(&Self::I1, &Self::I2) -> Self::R;
-    type F3: FnMut(&Self::I1, &Self::I2, &Self::I3) -> Self::R;
-    type F4: FnMut(&Self::I1, &Self::I2, &Self::I3, &Self::I4) -> Self::R;
-    type F5: FnMut(&Self::I1, &Self::I2, &Self::I3, &Self::I4, &Self::I5) -> Self::R;
-    type F6: FnMut(&Self::I1, &Self::I2, &Self::I3, &Self::I4, &Self::I5, &Self::I6) -> Self::R;
-    type B1: FnMut(&Self::BindLhs) -> Incr<Self::BindRhs>;
-    type Fold: FnMut(Self::R, &Self::I1) -> Self::R;
-    type Update: FnMut(Self::R, &Self::I1, &Self::I1) -> Self::R;
-    type WithOld: FnMut(Option<Self::R>, &Self::I1) -> (Self::R, bool);
-    type Recompute: FnMut() -> Self::R;
-    type ObsChange: FnMut(bool);
+    type F1: FnMut(&Self::I1) -> Self::R + NotObserver;
+    type FRef: Fn(&Self::I1) -> &Self::R + NotObserver;
+    type F2: FnMut(&Self::I1, &Self::I2) -> Self::R + NotObserver;
+    type F3: FnMut(&Self::I1, &Self::I2, &Self::I3) -> Self::R + NotObserver;
+    type F4: FnMut(&Self::I1, &Self::I2, &Self::I3, &Self::I4) -> Self::R + NotObserver;
+    type F5: FnMut(&Self::I1, &Self::I2, &Self::I3, &Self::I4, &Self::I5) -> Self::R + NotObserver;
+    type F6: FnMut(&Self::I1, &Self::I2, &Self::I3, &Self::I4, &Self::I5, &Self::I6) -> Self::R
+        + NotObserver;
+    type B1: FnMut(&Self::BindLhs) -> Incr<Self::BindRhs> + NotObserver;
+    type Fold: FnMut(Self::R, &Self::I1) -> Self::R + NotObserver;
+    type Update: FnMut(Self::R, &Self::I1, &Self::I1) -> Self::R + NotObserver;
+    type WithOld: FnMut(Option<Self::R>, &Self::I1) -> (Self::R, bool) + NotObserver;
+    type Recompute: FnMut() -> Self::R + NotObserver;
+    type ObsChange: FnMut(bool) + NotObserver;
 }
 
 pub(crate) enum Kind<G: NodeGenerics> {

--- a/src/kind/array_fold.rs
+++ b/src/kind/array_fold.rs
@@ -1,7 +1,9 @@
-use super::NodeGenerics;
-use super::{Incr, Value};
 use std::cell::RefCell;
 use std::fmt::{self, Debug};
+
+use super::NodeGenerics;
+use super::{Incr, Value};
+use crate::incrsan::NotObserver;
 
 pub(crate) struct ArrayFold<F, I, R> {
     pub(crate) init: R,
@@ -11,7 +13,7 @@ pub(crate) struct ArrayFold<F, I, R> {
 
 impl<F, I, R> ArrayFold<F, I, R>
 where
-    F: FnMut(R, &I) -> R,
+    F: FnMut(R, &I) -> R + NotObserver,
     I: Value,
     R: Value,
 {
@@ -27,7 +29,7 @@ where
 
 impl<F, I: Value, R: Value> NodeGenerics for ArrayFold<F, I, R>
 where
-    F: FnMut(R, &I) -> R + 'static,
+    F: FnMut(R, &I) -> R + 'static + NotObserver,
 {
     type R = R;
     type I1 = I;

--- a/src/kind/bind.rs
+++ b/src/kind/bind.rs
@@ -5,6 +5,7 @@ use std::{cell::Cell, fmt};
 use refl::Id;
 
 use super::NodeGenerics;
+use crate::incrsan::NotObserver;
 use crate::node::{ErasedNode, Input, Node, NodeId};
 use crate::scope::{BindScope, Scope};
 use crate::WeakNode;
@@ -14,7 +15,7 @@ pub(crate) struct BindNode<F, T, R>
 where
     R: Value,
     T: Value,
-    F: FnMut(&T) -> Incr<R> + 'static,
+    F: FnMut(&T) -> Incr<R> + 'static + NotObserver,
 {
     pub id_lhs_change: Cell<NodeId>,
     pub lhs_change: RefCell<Weak<Node<BindLhsChangeGen<F, T, R>>>>,
@@ -30,7 +31,7 @@ impl<F, T, R> BindScope for BindNode<F, T, R>
 where
     R: Value,
     T: Value,
-    F: FnMut(&T) -> Incr<R>,
+    F: FnMut(&T) -> Incr<R> + 'static + NotObserver,
 {
     fn id(&self) -> NodeId {
         self.id_lhs_change.get()
@@ -71,7 +72,7 @@ pub(crate) struct BindLhsChangeGen<F, T, R> {
 
 impl<F, T, R> NodeGenerics for BindLhsChangeGen<F, T, R>
 where
-    F: FnMut(&T) -> Incr<R> + 'static,
+    F: FnMut(&T) -> Incr<R> + 'static + NotObserver,
     T: Value,
     R: Value,
 {
@@ -94,7 +95,7 @@ pub(crate) struct BindNodeMainGen<F, T, R> {
 
 impl<F, T, R> NodeGenerics for BindNodeMainGen<F, T, R>
 where
-    F: FnMut(&T) -> Incr<R> + 'static,
+    F: FnMut(&T) -> Incr<R> + 'static + NotObserver,
     T: Value,
     R: Value,
 {
@@ -114,7 +115,7 @@ where
 
 impl<F, T, R> fmt::Debug for BindNode<F, T, R>
 where
-    F: FnMut(&T) -> Incr<R>,
+    F: FnMut(&T) -> Incr<R> + NotObserver,
     R: Value,
     T: Value,
 {

--- a/src/node_update.rs
+++ b/src/node_update.rs
@@ -1,8 +1,12 @@
-use super::stabilisation_num::StabilisationNum;
-use crate::node::Incremental;
 use std::cell::Cell;
 
+use super::stabilisation_num::StabilisationNum;
+use crate::node::Incremental;
+
+#[cfg(not(feature = "nightly-incrsan"))]
 pub(crate) type BoxedUpdateFn<T> = Box<dyn FnMut(NodeUpdate<&T>)>;
+#[cfg(feature = "nightly-incrsan")]
+pub(crate) type BoxedUpdateFn<T> = Box<dyn FnMut(NodeUpdate<&T>) + crate::incrsan::NotObserver>;
 
 #[derive(Copy, Clone, PartialEq, Eq, Hash, Debug)]
 enum Previously {

--- a/src/scope.rs
+++ b/src/scope.rs
@@ -2,8 +2,9 @@ use core::fmt;
 use std::rc::Weak;
 
 use super::{node::NodeId, NodeRef, WeakNode};
+use crate::incrsan::NotObserver;
 
-pub(crate) trait BindScope: fmt::Debug {
+pub(crate) trait BindScope: fmt::Debug + NotObserver {
     fn id(&self) -> NodeId;
     fn is_valid(&self) -> bool;
     fn is_necessary(&self) -> bool;

--- a/src/state.rs
+++ b/src/state.rs
@@ -2,6 +2,7 @@ use super::adjust_heights_heap::AdjustHeightsHeap;
 use super::kind;
 use super::node_update::NodeUpdateDelayed;
 use super::{CellIncrement, NodeRef, Value, WeakNode};
+use crate::incrsan::NotObserver;
 use crate::{SubscriptionToken, WeakMap};
 
 use super::internal_observer::{
@@ -174,7 +175,7 @@ impl State {
         f: F,
     ) -> Incr<R>
     where
-        F: FnMut(R, &T) -> R + 'static,
+        F: FnMut(R, &T) -> R + 'static + NotObserver,
     {
         if vec.is_empty() {
             return self.constant(init);

--- a/src/state/expert.rs
+++ b/src/state/expert.rs
@@ -7,8 +7,8 @@ use kind::expert::{IsEdge, PackedEdge};
 pub(crate) fn create<T, F, O>(state: &State, recompute: F, on_observability_change: O) -> Incr<T>
 where
     T: Value,
-    F: FnMut() -> T + 'static,
-    O: FnMut(bool) + 'static,
+    F: FnMut() -> T + 'static + NotObserver,
+    O: FnMut(bool) + 'static + NotObserver,
 {
     let node = Node::<kind::ExpertNode<T, F, O>>::create_rc(
         state.weak(),
@@ -37,8 +37,8 @@ pub(crate) fn create_cyclic<T, Cyclic, F, O>(
 where
     T: Value,
     Cyclic: FnOnce(WeakIncr<T>) -> F,
-    F: FnMut() -> T + 'static,
-    O: FnMut(bool) + 'static,
+    F: FnMut() -> T + 'static + NotObserver,
+    O: FnMut(bool) + 'static + NotObserver,
 {
     let node = Rc::<Node<_>>::new_cyclic(|weak| {
         let weak_incr = WeakIncr(weak.clone());

--- a/src/syntax.rs
+++ b/src/syntax.rs
@@ -10,7 +10,7 @@ macro_rules! map_builder {
         pub struct $n<$ifirst, $($upto_i,)+>(Incr<$ifirst>, $(Incr<$upto_i>,)+);
         impl<$ifirst: Value, $($upto_i: Value,)+> $n<$ifirst, $($upto_i),+> {
             /// Maps the incrementals in the (i1 % i2 % ...) syntax all at once.
-            pub fn map<R: Value>(&self, f: impl FnMut(&$ifirst, $(&$upto_i),+) -> R + 'static) -> Incr<R> {
+            pub fn map<R: Value>(&self, f: impl FnMut(&$ifirst, $(&$upto_i),+) -> R + 'static + crate::incrsan::NotObserver) -> Incr<R> {
                 let Self($vfirst, $($v),+) = self;
                 $vfirst.$map($($v),+, f)
             }

--- a/src/var.rs
+++ b/src/var.rs
@@ -1,4 +1,7 @@
-use crate::{node_generics_default, Value};
+use core::fmt::Debug;
+use std::cell::{Cell, RefCell};
+use std::rc::{Rc, Weak};
+
 #[cfg(test)]
 use test_log::test;
 
@@ -7,11 +10,11 @@ use super::node::{ErasedNode, Incremental, Node, NodeId};
 use super::stabilisation_num::StabilisationNum;
 use super::state::IncrStatus;
 use super::state::State;
-use super::{CellIncrement, Incr};
-
-use core::fmt::Debug;
-use std::cell::{Cell, RefCell};
-use std::rc::{Rc, Weak};
+use super::CellIncrement;
+use super::Incr;
+use crate::incrsan::NotObserver;
+use crate::node_generics_default;
+use crate::Value;
 
 pub(crate) struct VarGenerics<T: Value>(std::marker::PhantomData<T>);
 impl<R: Value> NodeGenerics for VarGenerics<R> {
@@ -27,7 +30,7 @@ impl<R: Value> NodeGenerics for VarGenerics<R> {
 // Rc-cycle-breaking on public::Var.
 pub(crate) type WeakVar = Weak<dyn ErasedVariable>;
 
-pub(crate) trait ErasedVariable: Debug {
+pub(crate) trait ErasedVariable: Debug + NotObserver {
     fn set_var_stabilise_end(&self);
     fn id(&self) -> NodeId;
     fn break_rc_cycle(&self);

--- a/tests/expert.rs
+++ b/tests/expert.rs
@@ -2,6 +2,7 @@ use std::{cell::RefCell, rc::Rc};
 // RUST_LOG_SPAN_EVENTS=enter,exit
 use test_log::test;
 
+use incremental::incrsan::NotObserver;
 use incremental::{expert::*, Incr, IncrState, Value};
 
 fn join<T: Value>(incr: &Incr<Incr<T>>) -> Incr<T> {
@@ -41,7 +42,10 @@ fn test_join() {
 }
 
 #[allow(dead_code)]
-fn bind<T: Value, R: Value>(incr: Incr<T>, mut f: impl FnMut(&T) -> Incr<R> + 'static) -> Incr<R> {
+fn bind<T: Value, R: Value>(
+    incr: Incr<T>,
+    mut f: impl FnMut(&T) -> Incr<R> + 'static + NotObserver,
+) -> Incr<R> {
     let prev_rhs: Rc<RefCell<Option<Dependency<R>>>> = Rc::new(None.into());
     let state = incr.state();
     let join = Node::<R>::new(&state, {

--- a/tests/fixed_point.rs
+++ b/tests/fixed_point.rs
@@ -1,14 +1,13 @@
 use std::{cell::Cell, rc::Rc};
 
+use incremental::incrsan::NotObserver;
 use incremental::{Incr, IncrState, Observer, SubscriptionToken, Update, Value, WeakState};
 use test_log::test;
-
-// fn fixed_point(f: impl FnMut (Vec<Incr<T>>) -> Vec<Incr<T>>)
 
 fn fixed_point<T: Value>(
     state: &WeakState,
     init: T,
-    mut f: impl FnMut(&mut T) -> T + 'static,
+    mut f: impl FnMut(&mut T) -> T + 'static + NotObserver,
 ) -> Incr<T> {
     let var = state.var(init);
     let v = var.clone();
@@ -108,7 +107,7 @@ fn dependencies() {
 fn using_cutoff<T: Value>(
     state: &WeakState,
     init: T,
-    mut f: impl FnMut(&mut T) -> T + 'static,
+    mut f: impl FnMut(&mut T) -> T + 'static + NotObserver,
 ) -> (Incr<T>, UntilStableValue<T>) {
     let var = state.var(init);
     // TODO: Cloning var and using it in a node may make  a ref cycle.
@@ -315,7 +314,7 @@ fn transitive_closure() {
 fn using_cutoff_bind<T: Value, F>(init: Incr<T>, f: F) -> (Incr<T>, UntilStableValue<T>)
 where
     T: Default,
-    F: FnMut(&mut T) -> T + 'static + Clone,
+    F: FnMut(&mut T) -> T + 'static + Clone + NotObserver,
 {
     let state = init.state();
     let var = state.var(T::default());


### PR DESCRIPTION
This has been an implicit requirement all along. In practice, as a codebase gets large, the likelihood of a someone putting huge state objects that hold observers into incremental nodes approaches 1. It's particularly annoying to debug because it only happens when the nodes are dropped, which might not happen in regular usage of e.g. a long-lived UI.

Incremental will panic if you try to *use* an observer from e.g inside a map node. However, it is also illegal to have them owned by e.g. a Map closure. Even if we could prevent the IncrState from panicking trying to tear down parts of its structure when this happens, it would still be valuable to prevent anyone trying to get Observers' values inside an incremental node.

The new `incremental::incrsan::NotObserver` allows you to statically check that you are not using Observers this way whatsoever. Switch to a nightly compiler and enable the `nightly-incrsan` feature.

An example of code caught by this check:

```rust

use incremental::*;

let state = IncrState::new();
let constant = state.constant(1);
let observer = constant.observe();
let map = constant.map(move |_| {
    let _ = observer.value();
    1234
});
```

Which gives you, from rustc:

```rust
error[E0277]: Type contains an incremental::Observer
   --> examples/bad.rs:7:28
    |
7   |       let map = constant.map(move |_| {
    |                          --- ^-------
    |                          |   |
    |  ________________________|___within this `{closure@examples/bad.rs:7:28: 7:36}`
    | |                        |
    | |                        required by a bound introduced by this call
8   | |         let _ = observer.value(); // invalid! will panic, so don't try!
9   | |         1234
10  | |     });
    | |_____^ Contains Observer<i32>, which is either an Observer or cannot be proven not to contain one.
    |
    = help: within `{closure@examples/bad.rs:7:28: 7:36}`, the trait `NotObserver` is not implemented for `Observer<i32>`, which is required by `{closure@examples/bad.rs:7:28: 7:36}: NotObserver`
    = note: Observers are the roots for garbage-collecting incremental nodes.
            They hold incrementals, not the other way round.
            If you need access to another incremental value in a map node, try map2.
            If you know this type has no observers, you can use incremental::incrsan::AssertNotObserver.

note: required because it's used within this closure
   --> examples/bad.rs:7:28
    |
7   |     let map = constant.map(move |_| {
    |                            ^^^^^^^^
note: required by a bound in `Incr::<T>::map`
   --> /home/cormac/code/external/incremental/src/incr.rs:129:56
    |
129 |     pub fn map<R: Value, F: FnMut(&T) -> R + 'static + NotObserver>(&self, f: F) -> Incr<R> {
    |                                                        ^^^^^^^^^^^ required by this bound in `Incr::<T>::map`
```