### PR TITLE
`incr_unordered_fold_with` + UnorderedFold + `incr_partition_mapi`

### DIFF
--- a/benches/shares_per_symbol.rs
+++ b/benches/shares_per_symbol.rs
@@ -4,7 +4,7 @@ use im_rc::{ordmap::Entry, OrdMap};
 use incremental::incrsan::NotObserver;
 use incremental::{Incr, IncrState, Value};
 use incremental_map::im_rc::IncrOrdMap;
-use incremental_map::Symmetric;
+use incremental_map::IncrMap;
 use tracing::Level;
 
 #[derive(Copy, Clone, PartialEq, Debug)]

--- a/benches/shares_per_symbol.rs
+++ b/benches/shares_per_symbol.rs
@@ -13,8 +13,10 @@ enum Dir {
     Sell,
 }
 
-type Symbol = u32;
-type Oid = u32;
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
+struct Symbol(u32);
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
+struct Oid(u32);
 
 #[derive(Clone, PartialEq)]
 struct Order {
@@ -42,15 +44,16 @@ fn index_by<KInner: Value + Ord, KOuter: Value + Ord, V: Value>(
     get_outer_index: impl Fn(&V) -> KOuter + Clone + 'static + NotObserver,
 ) -> Incr<OrdMap<KOuter, OrdMap<KInner, V>>> {
     let get_outer_index_ = get_outer_index.clone();
-    let add = move |mut acc: OrdMap<KOuter, OrdMap<KInner, V>>, key_inner: &KInner, value: &V| {
-        let index = get_outer_index_(value);
-        acc.entry(index)
-            .or_insert_with(|| OrdMap::new())
-            .insert(key_inner.clone(), value.clone());
-        acc
-    };
-    let remove =
-        move |mut acc: OrdMap<KOuter, OrdMap<KInner, V>>, key_inner: &KInner, value: &V| {
+    let indexed = map.incr_unordered_fold(
+        OrdMap::new(),
+        move |mut acc, key_inner, value| {
+            let index = get_outer_index_(value);
+            acc.entry(index)
+                .or_insert_with(|| OrdMap::new())
+                .insert(key_inner.clone(), value.clone());
+            acc
+        },
+        move |mut acc, key_inner, value| {
             let index = get_outer_index(value);
             match acc.entry(index) {
                 Entry::Vacant(_) => panic!(),
@@ -63,8 +66,9 @@ fn index_by<KInner: Value + Ord, KOuter: Value + Ord, V: Value>(
                 }
             }
             acc
-        };
-    let indexed = map.incr_unordered_fold(OrdMap::new(), add, remove, false);
+        },
+        false,
+    );
     #[cfg(debug_assertions)]
     indexed.set_graphviz_user_data("index_by");
     indexed
@@ -134,27 +138,26 @@ fn test_index_by() {
     );
 }
 
-fn shares(orders: Incr<OrdMap<Oid, Order>>) -> Incr<u32> {
-    orders.incr_unordered_fold(
-        0,
-        |acc, _k, x| acc + x.size,
-        |acc, _k, x| acc - x.size,
-        false,
-    )
-}
-
 fn shares_per_symbol(orders: Incr<OrdMap<Oid, Order>>) -> Incr<OrdMap<Symbol, u32>> {
-    orders
-        .pipe1(index_by, |x| x.sym)
-        .incr_mapi_(|_k, v| shares(v))
+    fn shares(_k: &Symbol, orders: Incr<OrdMap<Oid, Order>>) -> Incr<u32> {
+        orders.incr_unordered_fold(
+            0,
+            |acc, _k, x| acc + x.size,
+            |acc, _k, x| acc - x.size,
+            false,
+        )
+    }
+
+    let x = index_by(orders, |x| x.sym);
+    x.incr_mapi_(shares)
 }
 
 fn shares_per_symbol_flat(orders: Incr<OrdMap<Oid, Order>>) -> Incr<OrdMap<Symbol, u32>> {
     fn update_sym_map(
         op: fn(u32, u32) -> u32,
-    ) -> impl FnMut(OrdMap<Symbol, u32>, &Symbol, &Order) -> OrdMap<Symbol, u32> + NotObserver {
+    ) -> impl FnMut(OrdMap<Symbol, u32>, &Oid, &Order) -> OrdMap<Symbol, u32> + NotObserver {
         move |mut acc, _k, o| {
-            match acc.entry(*_k) {
+            match acc.entry(o.sym) {
                 Entry::Vacant(e) => {
                     e.insert(o.size);
                 }
@@ -185,11 +188,11 @@ fn random_order(rng: &mut impl rand::Rng) -> Order {
     };
     let id = rng.gen_range(0..u32::MAX);
     Order {
-        id,
+        id: Oid(id),
         dir,
         price,
         size,
-        sym,
+        sym: Symbol(sym),
     }
 }
 

--- a/incremental-map/Cargo.toml
+++ b/incremental-map/Cargo.toml
@@ -7,6 +7,10 @@ license = "MIT"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+# version separately from incremental
+[package.metadata.workspaces]
+independent = true
+
 [features]
 default = []
 im = ["dep:im-rc"]

--- a/incremental-map/Cargo.toml
+++ b/incremental-map/Cargo.toml
@@ -10,6 +10,7 @@ license = "MIT"
 [features]
 default = []
 im = ["dep:im-rc"]
+nightly-incrsan = ["incremental/nightly-incrsan"]
 
 [dependencies]
 im-rc = { workspace = true, optional = true }

--- a/incremental-map/src/btree_map.rs
+++ b/incremental-map/src/btree_map.rs
@@ -81,6 +81,14 @@ impl<K: Value + Ord, V: Value> IncrBTreeMap<K, V> for Incr<BTreeMap<K, V>> {
         incr_filter_mapi_generic_btree_map(self, FilterMapOperator(f, PhantomData), Some(cutoff))
     }
 
+    /// Merge two maps incrementally, where
+    ///
+    /// - if a key appears only in self, the predicate runs with [`MergeElement::Left`]
+    /// - if a key appears only in other, the predicate runs with [`MergeElement::Right`]
+    /// - if a key appears in both, the predicate runs with [`MergeElement::Both`]
+    ///
+    /// The predicate is only re-run for added/removed/modified keys in each map, using the
+    /// symmetric diff property.
     fn incr_merge<F, V2, R>(&self, other: &Incr<BTreeMap<K, V2>>, mut f: F) -> Incr<BTreeMap<K, R>>
     where
         V2: Value,

--- a/incremental-map/src/im_rc.rs
+++ b/incremental-map/src/im_rc.rs
@@ -278,6 +278,14 @@ pub trait IncrOrdMap<K: Value + Ord, V: Value> {
         V2: Value,
         F: FnMut(&K, Incr<V>) -> Incr<Option<V2>> + 'static + NotObserver;
 
+    /// Merge two maps incrementally, where
+    ///
+    /// - if a key appears only in self, the predicate runs with [`MergeElement::Left`]
+    /// - if a key appears only in other, the predicate runs with [`MergeElement::Right`]
+    /// - if a key appears in both, the predicate runs with [`MergeElement::Both`]
+    ///
+    /// The predicate is only re-run for added/removed/modified keys in each map, using the
+    /// symmetric diff property.
     fn incr_merge<F, V2, R>(&self, other: &Incr<OrdMap<K, V2>>, f: F) -> Incr<OrdMap<K, R>>
     where
         V2: Value,

--- a/incremental-map/src/im_rc.rs
+++ b/incremental-map/src/im_rc.rs
@@ -7,8 +7,8 @@ use incremental::incrsan::NotObserver;
 use incremental::{Cutoff, Incr, Value};
 
 use crate::symmetric_fold::{
-    DiffElement, GenericMap, MergeElement, MergeOnceWith, SymmetricDiffMap, SymmetricFoldMap,
-    SymmetricMapMap,
+    DiffElement, GenericMap, MergeElement, MergeOnceWith, MutableMap, SymmetricDiffMap,
+    SymmetricFoldMap, SymmetricMapMap,
 };
 
 use crate::{FilterMapOperator, MapOperator, Operator, Symmetric, WithOldIO};
@@ -100,15 +100,17 @@ impl<K: Ord + Clone, V: Clone> GenericMap<K, V> for OrdMap<K, V> {
     }
 }
 
-impl<K: Ord + Clone, V: Clone> SymmetricMapMap<K, V> for OrdMap<K, V> {
+impl<K: Ord + Clone, V: Clone> MutableMap<K, V> for OrdMap<K, V> {
     type UnderlyingMap = Self;
-
-    type OutputMap<V2: PartialEq + Clone> = OrdMap<K, V2>;
 
     #[inline]
     fn make_mut(&mut self) -> &mut Self::UnderlyingMap {
         self
     }
+}
+
+impl<K: Ord + Clone, V: Clone> SymmetricMapMap<K, V> for OrdMap<K, V> {
+    type OutputMap<V2: PartialEq + Clone> = OrdMap<K, V2>;
 
     fn filter_map_collect<V2: PartialEq + Clone>(
         &self,

--- a/incremental-map/src/im_rc.rs
+++ b/incremental-map/src/im_rc.rs
@@ -287,6 +287,22 @@ pub trait IncrOrdMap<K: Value + Ord, V: Value> {
         A: Value,
         B: Value,
         F: FnMut(&K, &V) -> Either<A, B> + 'static + NotObserver;
+
+    /// Partitions the input such that key-value pairs for which the predicate
+    /// returns `true` are in the left map, and pairs for which it return `false`
+    /// are on the right map.
+    fn incr_partition<F>(&self, mut pred: F) -> Incr<(OrdMap<K, V>, OrdMap<K, V>)>
+    where
+        F: FnMut(&K, &V) -> bool + 'static + NotObserver,
+    {
+        self.incr_partition_mapi(move |k, v| {
+            if pred(k, v) {
+                Either::Left(v.clone())
+            } else {
+                Either::Right(v.clone())
+            }
+        })
+    }
 }
 
 impl<K: Value + Ord, V: Value> IncrOrdMap<K, V> for Incr<OrdMap<K, V>> {

--- a/incremental-map/src/im_rc.rs
+++ b/incremental-map/src/im_rc.rs
@@ -11,7 +11,7 @@ use crate::symmetric_fold::{
     SymmetricFoldMap, SymmetricMapMap,
 };
 
-use crate::{FilterMapOperator, MapOperator, Operator, Symmetric, WithOldIO};
+use crate::{FilterMapOperator, IncrMap, MapOperator, Operator, WithOldIO};
 
 impl<'a, V> DiffElement<&'a V> {
     fn from_diff_item<K>(value: DiffItem<'a, K, V>) -> (&'a K, Self) {
@@ -284,6 +284,9 @@ pub trait IncrOrdMap<K: Value + Ord, V: Value> {
         R: Value,
         F: FnMut(&K, MergeElement<&V, &V2>) -> Option<R> + 'static + NotObserver;
 
+    /// Partitions the input such that key-value pairs for which the predicate
+    /// returns [`Either::Left`] are in the left map, and pairs for which it returns
+    /// [`Either::Right`] are in the right map.
     fn incr_partition_mapi<F, A, B>(&self, f: F) -> Incr<(OrdMap<K, A>, OrdMap<K, B>)>
     where
         A: Value,
@@ -291,8 +294,8 @@ pub trait IncrOrdMap<K: Value + Ord, V: Value> {
         F: FnMut(&K, &V) -> Either<A, B> + 'static + NotObserver;
 
     /// Partitions the input such that key-value pairs for which the predicate
-    /// returns `true` are in the left map, and pairs for which it return `false`
-    /// are on the right map.
+    /// returns `true` are in the left map, and pairs for which it returns `false`
+    /// are in the right map.
     fn incr_partition<F>(&self, mut pred: F) -> Incr<(OrdMap<K, V>, OrdMap<K, V>)>
     where
         F: FnMut(&K, &V) -> bool + 'static + NotObserver,

--- a/incremental-map/src/lib.rs
+++ b/incremental-map/src/lib.rs
@@ -98,17 +98,16 @@ impl<T: Value> WithOldIO<T> for Incr<T> {
     {
         let mut old_input: Option<(T, T2)> = None;
         // TODO: too much cloning
-        self.map2(other, |a, b| (a.clone(), b.clone()))
-            .map_with_old(move |old_opt, (a, b)| {
-                let oi = &mut old_input;
-                let (r, didchange) = f(
-                    old_opt.and_then(|x| oi.take().map(|(oia, oib)| (oia, oib, x))),
-                    a,
-                    b,
-                );
-                *oi = Some((a.clone(), b.clone()));
-                (r, didchange)
-            })
+        self.zip(other).map_with_old(move |old_opt, (a, b)| {
+            let oi = &mut old_input;
+            let (r, didchange) = f(
+                old_opt.and_then(|x| oi.take().map(|(oia, oib)| (oia, oib, x))),
+                a,
+                b,
+            );
+            *oi = Some((a.clone(), b.clone()));
+            (r, didchange)
+        })
     }
 }
 

--- a/incremental-map/src/lib.rs
+++ b/incremental-map/src/lib.rs
@@ -523,7 +523,7 @@ pub struct ClosureFold<M, K, V, R, FAdd, FRemove, FUpdate, FInitial> {
     add: FAdd,
     remove: FRemove,
     update: Option<FUpdate>,
-    specialized_initial: Option<FInitial>,
+    initial: Option<FInitial>,
     revert_to_init_when_empty: bool,
     phantom: PhantomData<(M, K, V, R)>,
 }
@@ -536,7 +536,7 @@ where {
             add: (),
             remove: (),
             update: None,
-            specialized_initial: None,
+            initial: None,
             revert_to_init_when_empty: false,
             phantom: PhantomData,
         }
@@ -554,7 +554,7 @@ where {
             add,
             remove,
             update: None,
-            specialized_initial: None,
+            initial: None,
             revert_to_init_when_empty: false,
             phantom: PhantomData,
         }
@@ -575,7 +575,7 @@ impl<M, K, V, R, FAdd_, FRemove_, FUpdate_, FInitial_>
             add,
             remove: self.remove,
             update: None,
-            specialized_initial: None,
+            initial: None,
             revert_to_init_when_empty: false,
             phantom: PhantomData,
         }
@@ -591,7 +591,7 @@ impl<M, K, V, R, FAdd_, FRemove_, FUpdate_, FInitial_>
             add: self.add,
             remove,
             update: None,
-            specialized_initial: None,
+            initial: None,
             revert_to_init_when_empty: false,
             phantom: PhantomData,
         }
@@ -607,15 +607,15 @@ impl<M, K, V, R, FAdd_, FRemove_, FUpdate_, FInitial_>
             add: self.add,
             remove: self.remove,
             update: Some(update),
-            specialized_initial: self.specialized_initial,
+            initial: self.initial,
             revert_to_init_when_empty: self.revert_to_init_when_empty,
             phantom: self.phantom,
         }
     }
 
-    pub fn specialized_initial<FInitial>(
+    pub fn initial<FInitial>(
         self,
-        specialized_initial: FInitial,
+        initial: FInitial,
     ) -> ClosureFold<M, K, V, R, FAdd_, FRemove_, FUpdate_, FInitial>
     where
         FInitial: for<'a> FnMut(R, &'a M) -> R + 'static + NotObserver,
@@ -624,7 +624,7 @@ impl<M, K, V, R, FAdd_, FRemove_, FUpdate_, FInitial_>
             add: self.add,
             remove: self.remove,
             update: self.update,
-            specialized_initial: Some(specialized_initial),
+            initial: Some(initial),
             revert_to_init_when_empty: self.revert_to_init_when_empty,
             phantom: self.phantom,
         }
@@ -637,7 +637,7 @@ impl<M, K, V, R, FAdd_, FRemove_, FUpdate_, FInitial_>
             add: self.add,
             remove: self.remove,
             update: self.update,
-            specialized_initial: self.specialized_initial,
+            initial: self.initial,
             revert_to_init_when_empty,
             phantom: self.phantom,
         }
@@ -679,7 +679,7 @@ where
     }
 
     fn initial_fold(&mut self, init: R, input: &M) -> R {
-        if let Some(closure) = &mut self.specialized_initial {
+        if let Some(closure) = &mut self.initial {
             closure(init, input)
         } else {
             input.nonincremental_fold(init, |acc, (k, v)| self.add(acc, k, v))

--- a/incremental-map/src/lib.rs
+++ b/incremental-map/src/lib.rs
@@ -23,6 +23,7 @@ pub mod prelude {
     pub use super::symmetric_fold::MutableMap;
     pub use super::symmetric_fold::SymmetricFoldMap;
     pub use super::symmetric_fold::SymmetricMapMap;
+    pub use super::ClosureFold;
     pub use super::IncrMap;
     pub use super::UnorderedFold;
 }

--- a/incremental-map/src/lib.rs
+++ b/incremental-map/src/lib.rs
@@ -454,10 +454,7 @@ where
 
     /// If we have emptied the map, can we just reset to the initial value?
     /// Or do we have to call remove() on everything that was removed?
-    #[inline]
-    fn revert_to_init_when_empty(&self) -> bool {
-        false
-    }
+    fn revert_to_init_when_empty(&self) -> bool;
 
     /// Optimize the initial fold
     fn initial_fold(&mut self, acc: R, input: &M) -> R {

--- a/incremental-map/src/lib.rs
+++ b/incremental-map/src/lib.rs
@@ -16,6 +16,8 @@ pub use self::symmetric_fold::{DiffElement, MergeElement};
 pub mod prelude {
     pub use super::btree_map::IncrBTreeMap;
     #[cfg(feature = "im")]
+    pub use super::im_rc::Either;
+    #[cfg(feature = "im")]
     pub use super::im_rc::IncrOrdMap;
     pub use super::symmetric_fold::DiffElement;
     pub use super::symmetric_fold::GenericMap;

--- a/incremental-map/src/symmetric_fold.rs
+++ b/incremental-map/src/symmetric_fold.rs
@@ -236,6 +236,33 @@ pub enum MergeElement<L, R> {
     Both(L, R),
 }
 
+impl<L, R> MergeElement<L, R> {
+    pub fn left(&self) -> Option<&L> {
+        match self {
+            Self::Left(l) | Self::Both(l, _) => Some(l),
+            _ => None,
+        }
+    }
+    pub fn into_left(self) -> Option<L> {
+        match self {
+            Self::Left(l) | Self::Both(l, _) => Some(l),
+            _ => None,
+        }
+    }
+    pub fn right(&self) -> Option<&R> {
+        match self {
+            Self::Right(r) | Self::Both(_, r) => Some(r),
+            _ => None,
+        }
+    }
+    pub fn into_right(self) -> Option<R> {
+        match self {
+            Self::Right(r) | Self::Both(_, r) => Some(r),
+            _ => None,
+        }
+    }
+}
+
 impl<L, R> MergeElement<&L, &R>
 where
     L: Clone,

--- a/incremental-map/src/symmetric_fold.rs
+++ b/incremental-map/src/symmetric_fold.rs
@@ -228,8 +228,11 @@ where
 
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
 pub enum MergeElement<L, R> {
+    /// A key in `incr_merge` was present only in the left map
     Left(L),
+    /// A key in `incr_merge` was present only in the right map
     Right(R),
+    /// A key in `incr_merge` was present in both maps
     Both(L, R),
 }
 

--- a/incremental-map/src/symmetric_fold.rs
+++ b/incremental-map/src/symmetric_fold.rs
@@ -84,26 +84,26 @@ where
 {
     a: Peekable<I>,
     b: Peekable<J>,
-    f: F,
+    fcmp: F,
     fused: Option<bool>,
 }
 
-impl<I: Iterator, J: Iterator, F: Fn(&I::Item, &J::Item) -> Ordering> MergeOnceWith<I, J, F> {
-    pub(crate) fn new(a: I, b: J, f: F) -> Self {
+impl<I: Iterator, J: Iterator, FCmp: Fn(&I::Item, &J::Item) -> Ordering> MergeOnceWith<I, J, FCmp> {
+    pub(crate) fn new(a: I, b: J, fcmp: FCmp) -> Self {
         Self {
             a: a.peekable(),
             b: b.peekable(),
-            f,
+            fcmp,
             fused: None,
         }
     }
 }
 
-impl<I, J, F> Iterator for MergeOnceWith<I, J, F>
+impl<I, J, FCmp> Iterator for MergeOnceWith<I, J, FCmp>
 where
     I: Iterator,
     J: Iterator,
-    F: Fn(&I::Item, &J::Item) -> Ordering,
+    FCmp: Fn(&I::Item, &J::Item) -> Ordering,
 {
     type Item = MergeElement<I::Item, J::Item>;
     fn next(&mut self) -> Option<Self::Item> {
@@ -111,7 +111,7 @@ where
             Some(true) => Ordering::Less,
             Some(false) => Ordering::Greater,
             None => match (self.a.peek(), self.b.peek()) {
-                (Some(a), Some(b)) => (self.f)(a, b),
+                (Some(a), Some(b)) => (self.fcmp)(a, b),
                 (Some(_), None) => {
                     self.fused = Some(true);
                     Ordering::Less

--- a/incremental-map/src/symmetric_fold.rs
+++ b/incremental-map/src/symmetric_fold.rs
@@ -130,18 +130,8 @@ where
                 .next()
                 .zip(self.b.next())
                 .map(|(a, b)| MergeElement::Both(a, b)),
-            Ordering::Less => {
-                if self.fused.is_none() {
-                    drop(self.b.next());
-                }
-                self.a.next().map(MergeElement::Left)
-            }
-            Ordering::Greater => {
-                if self.fused.is_none() {
-                    drop(self.a.next());
-                }
-                self.b.next().map(MergeElement::Right)
-            }
+            Ordering::Less => self.a.next().map(MergeElement::Left),
+            Ordering::Greater => self.b.next().map(MergeElement::Right),
         }
     }
 }

--- a/incremental-map/tests/integration.rs
+++ b/incremental-map/tests/integration.rs
@@ -218,4 +218,5 @@ fn incr_partition_mapi() {
     incr.stabilise();
     assert_eq!(left_.value(), ordmap! { 2i32 => "Hello", 3 => "three" });
     assert_eq!(right.value(), ordmap! { 4i32 => "four", 5 => "five" });
+    left_.save_dot_to_file("/tmp/incr_partition_mapi.dot");
 }

--- a/incremental-map/tests/integration.rs
+++ b/incremental-map/tests/integration.rs
@@ -269,7 +269,8 @@ fn test_types() {
     let fold = ClosureFold::new()
         .add(|acc, _k, v| acc + v)
         .remove(|acc, _k, v| acc - v)
-        .update(|acc, _k, old, new| acc - old + new);
+        .update(|acc, _k, old, new| acc - old + new)
+        .revert_to_init_when_empty(true);
     let folded = var.watch().incr_unordered_fold_with(0, fold);
     let obs = folded.observe();
     state.stabilise();

--- a/incremental-map/tests/integration.rs
+++ b/incremental-map/tests/integration.rs
@@ -3,7 +3,7 @@ use std::{cell::Cell, collections::BTreeMap, rc::Rc};
 use test_log::test;
 
 use incremental::{Incr, IncrState};
-use incremental_map::Symmetric;
+use incremental_map::{symmetric_fold::SymmetricFoldMap, Symmetric};
 
 #[derive(Debug)]
 struct CallCounter(&'static str, Cell<u32>);
@@ -216,9 +216,11 @@ fn incr_partition_mapi() {
 }
 
 use incremental::Value;
-use incremental_map::{IncrUnorderedFoldWith, UnorderedFold};
+use incremental_map::UnorderedFold;
+
 struct SumFold;
-impl<K: Value + Ord> UnorderedFold<K, i32, i32> for SumFold {
+
+impl<K: Value + Ord> UnorderedFold<im_rc::OrdMap<K, i32>, K, i32, i32> for SumFold {
     fn add(&mut self, acc: i32, _key: &K, value: &i32) -> i32 {
         acc + value
     }

--- a/incremental-map/tests/integration.rs
+++ b/incremental-map/tests/integration.rs
@@ -3,7 +3,7 @@ use std::{cell::Cell, collections::BTreeMap, rc::Rc};
 use test_log::test;
 
 use incremental::{Incr, IncrState};
-use incremental_map::{symmetric_fold::SymmetricFoldMap, Symmetric};
+use incremental_map::prelude::*;
 
 #[derive(Debug)]
 struct CallCounter(&'static str, Cell<u32>);

--- a/incremental-map/tests/integration.rs
+++ b/incremental-map/tests/integration.rs
@@ -204,13 +204,7 @@ fn incr_partition_mapi() {
 
     let incr = IncrState::new();
     let var = incr.var(ordmap! { 2i32 => "Hello", 3 => "three", 4 => "four", 5 => "five" });
-    let partitioned = var.watch().incr_partition_mapi(|key, value| {
-        if *key < 4 {
-            Either::Left(*value)
-        } else {
-            Either::Right(*value)
-        }
-    });
+    let partitioned = var.watch().incr_partition(|key, _value| *key < 4);
 
     let left_ = partitioned.map_ref(|(a, _)| a).observe();
     let right = partitioned.map_ref(|(_, b)| b).observe();

--- a/tests/fixed_point.rs
+++ b/tests/fixed_point.rs
@@ -269,7 +269,7 @@ fn two_fixedpoints_combined() {
     assert_eq!(combined.value(), 0);
 }
 
-#[cfg(feature = "im-rc")]
+#[cfg(feature = "im")]
 #[test]
 fn transitive_closure() {
     use im_rc::{hashmap, hashset, HashMap, HashSet};
@@ -346,7 +346,7 @@ where
     (output, until)
 }
 
-#[cfg(feature = "im-rc")]
+#[cfg(feature = "im")]
 mod transitive_closure {
     use super::*;
     use im_rc::{hashmap, hashset, HashMap, HashSet};


### PR DESCRIPTION
A bunch of improvements to incremental-map, for a bit more coverage of the OCaml version:

- benchmark fixed
- `incr_merge` now actually works, after writing some basic tests and fixing it
- new trait `UnorderedFold` (with default impls on the functions where OCaml uses function default parameters ~f)
- `incr_unordered_fold_with` to use that trait
- `incr_partition_map` which is pretty nice