### PR TITLE
Type erasure

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,6 @@ rust-analyzer = []
 nightly-incrsan = []
 
 [dependencies]
-refl = "0.2.1"
 smallvec = "1.10.0"
 tracing = { version = "0.1.37", features = [] }
 slotmap = { version = "1.0.6", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,13 +32,14 @@ im-rc = { version = "15.1.0" }
 [features]
 rust-analyzer = []
 nightly-incrsan = []
+nightly-miny = ["dep:miny"]
 
 [dependencies]
 smallvec = "1.10.0"
 tracing = { version = "0.1.37", features = [] }
 slotmap = { version = "1.0.6", optional = true }
 im-rc = { workspace = true, optional = true }
-miny = "2.0.2"
+miny = { version = "2.0.2", optional = true }
 
 [dev-dependencies]
 tracing-subscriber = { workspace = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,7 @@ smallvec = "1.10.0"
 tracing = { version = "0.1.37", features = [] }
 slotmap = { version = "1.0.6", optional = true }
 im-rc = { workspace = true, optional = true }
+miny = "2.0.2"
 
 [dev-dependencies]
 tracing-subscriber = { workspace = true }

--- a/src/adjust_heights_heap.rs
+++ b/src/adjust_heights_heap.rs
@@ -2,6 +2,7 @@ use crate::Invariant;
 
 use super::recompute_heap::RecomputeHeap;
 use super::NodeRef;
+use crate::node::ErasedNode;
 use std::collections::VecDeque;
 
 type Queue = VecDeque<NodeRef>;

--- a/src/boxes.rs
+++ b/src/boxes.rs
@@ -1,0 +1,55 @@
+#[cfg(not(feature = "nightly-miny"))]
+#[macro_use]
+mod impls {
+    macro_rules! new_unsized {
+        ($expr:expr $(,)?) => {
+            ::std::boxed::Box::new($expr)
+        };
+    }
+    /// Type alias for [Box], because feature nightly-miny is disabled.
+    pub(crate) type SmallBox<T> = Box<T>;
+    pub(crate) use new_unsized;
+
+    use crate::ValueInternal;
+    pub fn downcast_inner<V: 'static>(boxed: SmallBox<dyn ValueInternal>) -> Option<V> {
+        let boxed = downcast_box(boxed)?;
+        Some(*boxed)
+    }
+    fn downcast_box<V: 'static>(boxed: SmallBox<dyn ValueInternal>) -> Option<SmallBox<V>> {
+        if !boxed.as_any().is::<V>() {
+            return None;
+        }
+        // Safety: we checked that boxed holds V
+        Some(unsafe { downcast_unchecked(boxed) })
+    }
+    unsafe fn downcast_unchecked<V: 'static>(boxed: SmallBox<dyn ValueInternal>) -> SmallBox<V> {
+        debug_assert!(boxed.as_any().is::<V>());
+        // Safety: passed to caller
+        unsafe {
+            let raw: *mut (dyn ValueInternal) = Box::into_raw(boxed);
+            Box::from_raw(raw as *mut V)
+        }
+    }
+}
+
+#[cfg(feature = "nightly-miny")]
+#[macro_use]
+mod impls {
+    use crate::ValueInternal;
+
+    macro_rules! new_unsized {
+        ($expr:expr $(,)?) => {
+            ::miny::Miny::new_unsized($expr)
+        };
+    }
+    /// Type alias for [miny::Miny], because feature nightly-miny is enabled.
+    pub type SmallBox<T> = miny::Miny<T>;
+    pub(crate) use new_unsized;
+
+    pub fn downcast_inner<V: 'static>(boxed: SmallBox<dyn ValueInternal>) -> Option<V> {
+        // I'm not convinced that Miny::downcast is not too general -- it may allow
+        miny::Miny::downcast(boxed).ok()
+    }
+}
+
+pub(crate) use impls::*;

--- a/src/cutoff.rs
+++ b/src/cutoff.rs
@@ -1,8 +1,34 @@
+use std::any::Any;
+
 use crate::incrsan::NotObserver;
+
+pub(crate) struct ErasedCutoff {
+    should_cutoff: Box<dyn CutoffClosure<dyn Any>>,
+}
+
+impl ErasedCutoff {
+    pub(crate) fn new<T: PartialEq + Clone + 'static>(mut cutoff: Cutoff<T>) -> Self {
+        Self {
+            // codegen: one copy of this closure is generated for each T
+            should_cutoff: Box::new(move |a: &dyn Any, b: &dyn Any| -> bool {
+                let Some(a) = a.downcast_ref::<T>() else {
+                    return false;
+                };
+                let Some(b) = b.downcast_ref::<T>() else {
+                    return false;
+                };
+                cutoff.should_cutoff(a, b)
+            }),
+        }
+    }
+    pub(crate) fn should_cutoff(&mut self, a: &dyn Any, b: &dyn Any) -> bool {
+        (&mut *self.should_cutoff)(a, b)
+    }
+}
 
 #[derive(Clone)]
 #[non_exhaustive]
-pub enum Cutoff<T> {
+pub enum Cutoff<T: ?Sized> {
     Always,
     Never,
     PartialEq,
@@ -10,11 +36,11 @@ pub enum Cutoff<T> {
     FnBoxed(Box<dyn CutoffClosure<T>>),
 }
 
-pub trait CutoffClosure<T>: FnMut(&T, &T) -> bool + NotObserver {
+pub trait CutoffClosure<T: ?Sized>: FnMut(&T, &T) -> bool + NotObserver {
     fn clone_box(&self) -> Box<dyn CutoffClosure<T>>;
 }
 
-impl<T, F> CutoffClosure<T> for F
+impl<T: ?Sized, F> CutoffClosure<T> for F
 where
     F: FnMut(&T, &T) -> bool + Clone + 'static + NotObserver,
 {
@@ -29,7 +55,7 @@ impl<T> Clone for Box<dyn CutoffClosure<T>> {
     }
 }
 
-impl<T> Cutoff<T>
+impl<T: ?Sized> Cutoff<T>
 where
     T: PartialEq,
 {

--- a/src/cutoff.rs
+++ b/src/cutoff.rs
@@ -68,4 +68,11 @@ where
             Self::FnBoxed(comparator) => comparator(a, b),
         }
     }
+
+    pub(crate) fn erased(self) -> ErasedCutoff
+    where
+        T: Clone + 'static,
+    {
+        ErasedCutoff::new(self)
+    }
 }

--- a/src/incr.rs
+++ b/src/incr.rs
@@ -258,11 +258,6 @@ impl<T: Value> Incr<T> {
             state.weak(),
             state.current_scope(),
             Kind::BindMain {
-                casts: kind::BindMainId {
-                    rhs_r: refl::refl(),
-                    // input_rhs_i1: refl::refl(),
-                    // input_lhs_i2: refl::refl(),
-                },
                 bind: bind.clone(),
                 lhs_change: lhs_change.clone(),
             },

--- a/src/incr.rs
+++ b/src/incr.rs
@@ -170,10 +170,10 @@ impl<T: Value> Incr<T> {
             };
             let mapper = kind::MapNode {
                 input: self.clone().node,
-                mapper: f.into(),
+                mapper: Box::new(RefCell::new(f)),
             };
             let state = self.node.state();
-            let mut node = Node::<kind::MapNode<_, T, R>>::create(
+            let mut node = Node::<kind::MapNode<T, R>>::create(
                 state.weak(),
                 state.current_scope.borrow().clone(),
                 Kind::Map(mapper),

--- a/src/incr.rs
+++ b/src/incr.rs
@@ -269,12 +269,7 @@ impl<T: Value> Incr<T> {
         let lhs_change = Node::<kind::BindLhsChangeGen<R>>::create_rc(
             state.weak(),
             state.current_scope(),
-            Kind::BindLhsChange {
-                casts: kind::BindLhsId {
-                    r_unit: refl::refl(),
-                },
-                bind: bind.clone(),
-            },
+            Kind::BindLhsChange { bind: bind.clone() },
         );
         let main = Node::<kind::BindNodeMainGen<R>>::create_rc(
             state.weak(),

--- a/src/incr.rs
+++ b/src/incr.rs
@@ -149,13 +149,14 @@ impl<T: Value> Incr<T> {
         let node = Node::<kind::MapRefNode<R>>::create_rc(
             state.weak(),
             state.current_scope(),
-            Kind::MapRef(kind::MapRefNode {
+            Kind::MapRef(kind::MapRefNode::<R> {
                 input: self.node.packed(),
                 did_change: true.into(),
                 mapper: Box::new(move |x: &dyn Any| {
                     let x = x.downcast_ref::<T>().unwrap();
-                    f(x)
+                    f(x) as &dyn Any
                 }),
+                phantom: std::marker::PhantomData,
             }),
         );
         Incr { node }

--- a/src/incr.rs
+++ b/src/incr.rs
@@ -278,7 +278,6 @@ impl<T: Value> Incr<T> {
             state.current_scope(),
             Kind::BindLhsChange {
                 casts: kind::BindLhsId {
-                    input_lhs_i2: refl::refl(),
                     r_unit: refl::refl(),
                 },
                 bind: bind.clone(),

--- a/src/incr.rs
+++ b/src/incr.rs
@@ -5,7 +5,7 @@ use std::hash::Hash;
 use std::rc::{Rc, Weak};
 
 use super::kind::{self, Kind};
-use super::node::{Incremental, Input, Node, NodeId};
+use super::node::{ErasedNode, Incremental, Input, Node, NodeId};
 use super::scope::{BindScope, Scope};
 use crate::incrsan::NotObserver;
 use crate::node_update::OnUpdateHandler;
@@ -242,7 +242,7 @@ impl<T: Value> Incr<T> {
             all_nodes_created_on_rhs: RefCell::new(vec![]),
             lhs_change: Weak::new().into(),
             id_lhs_change: Cell::new(NodeId(0)),
-            main: Weak::new().into(),
+            main: RefCell::new(Weak::<Node<kind::BindLhsChangeGen<R>>>::new()),
         });
         let lhs_change = Node::<kind::BindLhsChangeGen<R>>::create_rc(
             state.weak(),
@@ -260,7 +260,7 @@ impl<T: Value> Incr<T> {
             Kind::BindMain {
                 casts: kind::BindMainId {
                     rhs_r: refl::refl(),
-                    input_rhs_i1: refl::refl(),
+                    // input_rhs_i1: refl::refl(),
                     // input_lhs_i2: refl::refl(),
                 },
                 bind: bind.clone(),
@@ -271,7 +271,7 @@ impl<T: Value> Incr<T> {
             let mut bind_lhs_change = bind.lhs_change.borrow_mut();
             let mut bind_main = bind.main.borrow_mut();
             *bind_lhs_change = Rc::downgrade(&lhs_change);
-            *bind_main = Rc::downgrade(&main);
+            *bind_main = main.weak();
             bind.id_lhs_change.set(lhs_change.id);
         }
 

--- a/src/incr.rs
+++ b/src/incr.rs
@@ -230,7 +230,7 @@ impl<T: Value> Incr<T> {
         let state = self.node.state();
         let bind = Rc::new_cyclic(|weak| kind::BindNode {
             lhs: self.clone().node,
-            mapper: f.into(),
+            mapper: RefCell::new(Box::new(f)),
             rhs: RefCell::new(None),
             rhs_scope: Scope::Bind(weak.clone() as Weak<dyn BindScope>).into(),
             all_nodes_created_on_rhs: RefCell::new(vec![]),
@@ -238,7 +238,7 @@ impl<T: Value> Incr<T> {
             id_lhs_change: Cell::new(NodeId(0)),
             main: Weak::new().into(),
         });
-        let lhs_change = Node::<kind::BindLhsChangeGen<F, T, R>>::create_rc(
+        let lhs_change = Node::<kind::BindLhsChangeGen<T, R>>::create_rc(
             state.weak(),
             state.current_scope(),
             Kind::BindLhsChange {
@@ -248,7 +248,7 @@ impl<T: Value> Incr<T> {
                 bind: bind.clone(),
             },
         );
-        let main = Node::<kind::BindNodeMainGen<F, T, R>>::create_rc(
+        let main = Node::<kind::BindNodeMainGen<T, R>>::create_rc(
             state.weak(),
             state.current_scope(),
             Kind::BindMain {

--- a/src/incr.rs
+++ b/src/incr.rs
@@ -172,12 +172,13 @@ impl<T: Value> Incr<T> {
                 let weak = WeakIncr(node_weak.clone());
                 move |t: &dyn Any| {
                     let t = t.downcast_ref().unwrap();
-                    cyclic(weak.clone(), t)
+                    miny::Miny::new_unsized(cyclic(weak.clone(), t))
                 }
             };
             let mapper = kind::MapNode {
                 input: self.node.packed(),
                 mapper: Box::new(RefCell::new(f)),
+                phantom: Default::default(),
             };
             let state = self.node.state();
             let mut node = Node::<kind::MapNode<R>>::create(

--- a/src/incr.rs
+++ b/src/incr.rs
@@ -126,21 +126,6 @@ impl<T: Value> Incr<T> {
         })
     }
 
-    pub fn map<R: Value, F: FnMut(&T) -> R + 'static + NotObserver>(&self, f: F) -> Incr<R> {
-        let mapper = kind::MapNode {
-            input: self.clone().node,
-            mapper: f.into(),
-        };
-        let state = self.node.state();
-        let node = Node::<kind::MapNode<F, T, R>>::create_rc(
-            state.weak(),
-            state.current_scope.borrow().clone(),
-            Kind::Map(mapper),
-        );
-
-        Incr { node }
-    }
-
     /// Turn two incrementals into a tuple incremental.
     /// Aka `both` in OCaml. This is named `zip` to match [Option::zip] and [Iterator::zip].
     pub fn zip<T2: Value>(&self, other: &Incr<T2>) -> Incr<(T, T2)> {
@@ -222,26 +207,6 @@ impl<T: Value> Incr<T> {
             state.weak(),
             state.current_scope(),
             Kind::MapWithOld(kind::MapWithOld::new(self.node.clone(), f)),
-        );
-        Incr { node }
-    }
-
-    pub fn map2<F, T2, R>(&self, other: &Incr<T2>, f: F) -> Incr<R>
-    where
-        T2: Value,
-        R: Value,
-        F: FnMut(&T, &T2) -> R + 'static + NotObserver,
-    {
-        let mapper = kind::Map2Node {
-            one: self.clone().node,
-            two: other.clone().node,
-            mapper: f.into(),
-        };
-        let state = self.node.state();
-        let node = Node::<kind::Map2Node<F, T, T2, R>>::create_rc(
-            state.weak(),
-            state.current_scope.borrow().clone(),
-            Kind::Map2(mapper),
         );
         Incr { node }
     }

--- a/src/incr.rs
+++ b/src/incr.rs
@@ -276,7 +276,7 @@ impl<T: Value> Incr<T> {
             state.current_scope(),
             Kind::BindMain {
                 bind: bind.clone(),
-                lhs_change: lhs_change.clone(),
+                lhs_change: lhs_change.packed(),
             },
         );
         {

--- a/src/internal_observer.rs
+++ b/src/internal_observer.rs
@@ -2,6 +2,7 @@ use super::node::ErasedNode;
 use super::node_update::{NodeUpdateDelayed, OnUpdateHandler};
 use super::stabilisation_num::StabilisationNum;
 use super::state::{IncrStatus, State};
+use crate::node::Node;
 use crate::node_update::HandleUpdate;
 use std::cell::RefCell;
 use std::collections::HashMap;
@@ -48,18 +49,13 @@ pub(crate) trait ErasedObserver: Debug + NotObserver {
     fn id(&self) -> ObserverId;
     fn state(&self) -> &Cell<ObserverState>;
     fn observing_packed(&self) -> NodeRef;
-    fn observing_erased(&self) -> &dyn ErasedNode;
+    fn observing_erased(&self) -> &Node;
     fn disallow_future_use(&self, state: &State);
     fn num_handlers(&self) -> i32;
     fn add_to_observed_node(&self);
     fn remove_from_observed_node(&self);
     fn unsubscribe(&self, token: SubscriptionToken) -> Result<(), ObserverError>;
-    fn run_all(
-        &self,
-        input: &dyn ErasedNode,
-        node_update: NodeUpdateDelayed,
-        now: StabilisationNum,
-    );
+    fn run_all(&self, input: &Node, node_update: NodeUpdateDelayed, now: StabilisationNum);
 }
 
 impl<T: Value> ErasedObserver for InternalObserver<T> {
@@ -72,7 +68,7 @@ impl<T: Value> ErasedObserver for InternalObserver<T> {
     fn observing_packed(&self) -> NodeRef {
         self.observing.node.clone().packed()
     }
-    fn observing_erased(&self) -> &dyn ErasedNode {
+    fn observing_erased(&self) -> &Node {
         self.observing.node.erased()
     }
     fn disallow_future_use(&self, state: &State) {
@@ -143,12 +139,7 @@ impl<T: Value> ErasedObserver for InternalObserver<T> {
             }
         }
     }
-    fn run_all(
-        &self,
-        input: &dyn ErasedNode,
-        node_update: NodeUpdateDelayed,
-        now: StabilisationNum,
-    ) {
+    fn run_all(&self, input: &Node, node_update: NodeUpdateDelayed, now: StabilisationNum) {
         let mut handlers = self.on_update_handlers.borrow_mut();
         for (id, handler) in handlers.iter_mut() {
             tracing::trace!("running update handler with id {id:?}");

--- a/src/kind.rs
+++ b/src/kind.rs
@@ -25,7 +25,7 @@ macro_rules! node_generics_default {
     (@single I5) => { type I5 = (); };
     (@single I6) => { type I6 = (); };
 
-    (@single BindLhs) => { type BindLhs = (); };
+    (@single BindLhs) => { /* snipped */ };
     (@single BindRhs) => { type BindRhs = (); };
     (@single B1) => { /* snipped */ };
     (@single Fold) => { /* snipped */ };
@@ -54,7 +54,6 @@ pub(crate) use map::*;
 
 pub(crate) trait NodeGenerics: 'static + NotObserver {
     type R: Value;
-    type BindLhs: Value;
     type BindRhs: Value;
     type I1: Value;
     type I2: Value;
@@ -82,16 +81,16 @@ pub(crate) enum Kind<G: NodeGenerics> {
     Map6(map::Map6Node<G::I1, G::I2, G::I3, G::I4, G::I5, G::I6, G::R>),
     BindLhsChange {
         casts: bind::BindLhsId<G>,
-        bind: Rc<bind::BindNode<G::BindLhs, G::BindRhs>>,
+        bind: Rc<bind::BindNode<G::BindRhs>>,
     },
     BindMain {
         casts: bind::BindMainId<G>,
-        bind: Rc<bind::BindNode<G::BindLhs, G::BindRhs>>,
+        bind: Rc<bind::BindNode<G::BindRhs>>,
         // Ownership goes
         // a Kind::BindMain holds a BindNode & the BindLhsChange
         // a Kind::BindLhsChange holds a BindNode
         // BindNode holds weak refs to both
-        lhs_change: Rc<Node<bind::BindLhsChangeGen<G::BindLhs, G::BindRhs>>>,
+        lhs_change: Rc<Node<bind::BindLhsChangeGen<G::BindRhs>>>,
     },
     Expert(expert::ExpertNode<G::R>),
 }
@@ -216,13 +215,12 @@ impl<G: NodeGenerics> Kind<G> {
                         )
                     }
                     Kind::BindLhsChange { .. } => {
-                        write!(f, "BindLhsChange<{}>", std::any::type_name::<G::BindLhs>(),)
+                        write!(f, "BindLhsChange",)
                     }
                     Kind::BindMain { .. } => {
                         write!(
                             f,
-                            "BindMain<({}) -> {}>",
-                            std::any::type_name::<G::BindLhs>(),
+                            "BindMain<(lhs: dynamic) -> {}>",
                             std::any::type_name::<G::BindRhs>()
                         )
                     }

--- a/src/kind.rs
+++ b/src/kind.rs
@@ -27,7 +27,7 @@ macro_rules! node_generics_default {
 
     (@single BindLhs) => { type BindLhs = (); };
     (@single BindRhs) => { type BindRhs = (); };
-    (@single B1) => { type B1 = fn(&Self::BindLhs) -> Incr<Self::BindRhs>; };
+    (@single B1) => { /* snipped */ };
     (@single Fold) => { /* snipped */ };
     (@single Update) => { /* snipped */ };
     (@single WithOld) => { type WithOld = fn(Option<Self::R>, &Self::I1) -> (Self::R, bool); };
@@ -63,7 +63,6 @@ pub(crate) trait NodeGenerics: 'static + NotObserver {
     type I5: Value;
     type I6: Value;
     type FRef: Fn(&Self::I1) -> &Self::R + NotObserver;
-    type B1: FnMut(&Self::BindLhs) -> Incr<Self::BindRhs> + NotObserver;
     type WithOld: FnMut(Option<Self::R>, &Self::I1) -> (Self::R, bool) + NotObserver;
 }
 
@@ -83,16 +82,16 @@ pub(crate) enum Kind<G: NodeGenerics> {
     Map6(map::Map6Node<G::I1, G::I2, G::I3, G::I4, G::I5, G::I6, G::R>),
     BindLhsChange {
         casts: bind::BindLhsId<G>,
-        bind: Rc<bind::BindNode<G::B1, G::BindLhs, G::BindRhs>>,
+        bind: Rc<bind::BindNode<G::BindLhs, G::BindRhs>>,
     },
     BindMain {
         casts: bind::BindMainId<G>,
-        bind: Rc<bind::BindNode<G::B1, G::BindLhs, G::BindRhs>>,
+        bind: Rc<bind::BindNode<G::BindLhs, G::BindRhs>>,
         // Ownership goes
         // a Kind::BindMain holds a BindNode & the BindLhsChange
         // a Kind::BindLhsChange holds a BindNode
         // BindNode holds weak refs to both
-        lhs_change: Rc<Node<bind::BindLhsChangeGen<G::B1, G::BindLhs, G::BindRhs>>>,
+        lhs_change: Rc<Node<bind::BindLhsChangeGen<G::BindLhs, G::BindRhs>>>,
     },
     Expert(expert::ExpertNode<G::R>),
 }

--- a/src/kind.rs
+++ b/src/kind.rs
@@ -11,12 +11,12 @@ macro_rules! node_generics_default {
     (@fn $name:ident ( $($param:ident),* )) => {
         type $name = fn($(&Self::$param,)*) -> Self::R;
     };
-    (@single F1) => { node_generics_default!{ @fn F1 (I1) } };
-    (@single F2) => { node_generics_default!{ @fn F2 (I1, I2) } };
-    (@single F3) => { node_generics_default!{ @fn F3 (I1, I2, I3) } };
-    (@single F4) => { node_generics_default!{ @fn F4 (I1, I2, I3, I4) } };
-    (@single F5) => { node_generics_default!{ @fn F5 (I1, I2, I3, I4, I5) } };
-    (@single F6) => { node_generics_default!{ @fn F6 (I1, I2, I3, I4, I5, I6) } };
+    (@single F1) => { /* snipped */ };
+    (@single F2) => { /* snipped */ };
+    (@single F3) => { /* snipped */ };
+    (@single F4) => { /* snipped */ };
+    (@single F5) => { /* snipped */ };
+    (@single F6) => { /* snipped */ };
 
     (@single I1) => { type I1 = (); };
     (@single I2) => { type I2 = (); };
@@ -62,14 +62,7 @@ pub(crate) trait NodeGenerics: 'static + NotObserver {
     type I4: Value;
     type I5: Value;
     type I6: Value;
-    type F1: FnMut(&Self::I1) -> Self::R + NotObserver;
     type FRef: Fn(&Self::I1) -> &Self::R + NotObserver;
-    type F2: FnMut(&Self::I1, &Self::I2) -> Self::R + NotObserver;
-    type F3: FnMut(&Self::I1, &Self::I2, &Self::I3) -> Self::R + NotObserver;
-    type F4: FnMut(&Self::I1, &Self::I2, &Self::I3, &Self::I4) -> Self::R + NotObserver;
-    type F5: FnMut(&Self::I1, &Self::I2, &Self::I3, &Self::I4, &Self::I5) -> Self::R + NotObserver;
-    type F6: FnMut(&Self::I1, &Self::I2, &Self::I3, &Self::I4, &Self::I5, &Self::I6) -> Self::R
-        + NotObserver;
     type B1: FnMut(&Self::BindLhs) -> Incr<Self::BindRhs> + NotObserver;
     type Fold: FnMut(Self::R, &Self::I1) -> Self::R + NotObserver;
     type Update: FnMut(Self::R, &Self::I1, &Self::I1) -> Self::R + NotObserver;
@@ -82,14 +75,14 @@ pub(crate) enum Kind<G: NodeGenerics> {
     // We have a strong reference to the Var, because (e.g.) the user's public::Var
     // may have been set and then dropped before the next stabilise().
     Var(Rc<Var<G::R>>),
-    Map(map::MapNode<G::F1, G::I1, G::R>),
+    Map(map::MapNode<G::I1, G::R>),
     MapWithOld(map::MapWithOld<G::WithOld, G::I1, G::R>),
     MapRef(map::MapRefNode<G::FRef, G::I1, G::R>),
-    Map2(map::Map2Node<G::F2, G::I1, G::I2, G::R>),
-    Map3(map::Map3Node<G::F3, G::I1, G::I2, G::I3, G::R>),
-    Map4(map::Map4Node<G::F4, G::I1, G::I2, G::I3, G::I4, G::R>),
-    Map5(map::Map5Node<G::F5, G::I1, G::I2, G::I3, G::I4, G::I5, G::R>),
-    Map6(map::Map6Node<G::F6, G::I1, G::I2, G::I3, G::I4, G::I5, G::I6, G::R>),
+    Map2(map::Map2Node<G::I1, G::I2, G::R>),
+    Map3(map::Map3Node<G::I1, G::I2, G::I3, G::R>),
+    Map4(map::Map4Node<G::I1, G::I2, G::I3, G::I4, G::R>),
+    Map5(map::Map5Node<G::I1, G::I2, G::I3, G::I4, G::I5, G::R>),
+    Map6(map::Map6Node<G::I1, G::I2, G::I3, G::I4, G::I5, G::I6, G::R>),
     BindLhsChange {
         casts: bind::BindLhsId<G>,
         bind: Rc<bind::BindNode<G::B1, G::BindLhs, G::BindRhs>>,

--- a/src/kind.rs
+++ b/src/kind.rs
@@ -33,7 +33,7 @@ macro_rules! node_generics_default {
     (@single WithOld) => { type WithOld = fn(Option<Self::R>, &Self::I1) -> (Self::R, bool); };
     (@single FRef) => { type FRef = fn(&Self::I1) -> &Self::R; };
     (@single Recompute) => { type Recompute = fn() -> Self::R; };
-    (@single ObsChange) => { type ObsChange = fn(bool); };
+    (@single ObsChange) => { /* snipped */ };
 
     ($($ident:ident),*) => {
         $(
@@ -75,7 +75,6 @@ pub(crate) trait NodeGenerics: 'static + NotObserver {
     type Update: FnMut(Self::R, &Self::I1, &Self::I1) -> Self::R + NotObserver;
     type WithOld: FnMut(Option<Self::R>, &Self::I1) -> (Self::R, bool) + NotObserver;
     type Recompute: FnMut() -> Self::R + NotObserver;
-    type ObsChange: FnMut(bool) + NotObserver;
 }
 
 pub(crate) enum Kind<G: NodeGenerics> {
@@ -105,7 +104,7 @@ pub(crate) enum Kind<G: NodeGenerics> {
         // BindNode holds weak refs to both
         lhs_change: Rc<Node<bind::BindLhsChangeGen<G::B1, G::BindLhs, G::BindRhs>>>,
     },
-    Expert(expert::ExpertNode<G::R, G::Recompute, G::ObsChange>),
+    Expert(expert::ExpertNode<G::R, G::Recompute>),
 }
 
 impl<G: NodeGenerics> Debug for Kind<G> {

--- a/src/kind.rs
+++ b/src/kind.rs
@@ -29,7 +29,7 @@ macro_rules! node_generics_default {
     (@single BindRhs) => { type BindRhs = (); };
     (@single B1) => { type B1 = fn(&Self::BindLhs) -> Incr<Self::BindRhs>; };
     (@single Fold) => { type Fold = fn(Self::R, &Self::I1) -> Self::R; };
-    (@single Update) => { type Update = fn(Self::R, &Self::I1, &Self::I1) -> Self::R; };
+    (@single Update) => { /* snipped */ };
     (@single WithOld) => { type WithOld = fn(Option<Self::R>, &Self::I1) -> (Self::R, bool); };
     (@single FRef) => { type FRef = fn(&Self::I1) -> &Self::R; };
     (@single Recompute) => { /* snipped */ };
@@ -65,7 +65,6 @@ pub(crate) trait NodeGenerics: 'static + NotObserver {
     type FRef: Fn(&Self::I1) -> &Self::R + NotObserver;
     type B1: FnMut(&Self::BindLhs) -> Incr<Self::BindRhs> + NotObserver;
     type Fold: FnMut(Self::R, &Self::I1) -> Self::R + NotObserver;
-    type Update: FnMut(Self::R, &Self::I1, &Self::I1) -> Self::R + NotObserver;
     type WithOld: FnMut(Option<Self::R>, &Self::I1) -> (Self::R, bool) + NotObserver;
 }
 

--- a/src/kind.rs
+++ b/src/kind.rs
@@ -83,10 +83,10 @@ pub(crate) enum Kind<G: NodeGenerics> {
     Map6(map::Map6Node<G::R>),
     BindLhsChange {
         casts: bind::BindLhsId<G>,
-        bind: Rc<bind::BindNode<G::BindRhs>>,
+        bind: Rc<bind::BindNode>,
     },
     BindMain {
-        bind: Rc<bind::BindNode<G::R>>,
+        bind: Rc<bind::BindNode>,
         // Ownership goes
         // a Kind::BindMain holds a BindNode & the BindLhsChange
         // a Kind::BindLhsChange holds a BindNode

--- a/src/kind.rs
+++ b/src/kind.rs
@@ -19,7 +19,7 @@ macro_rules! node_generics_default {
     (@single F6) => { /* snipped */ };
 
     (@single I1) => { type I1 = (); };
-    (@single I2) => { type I2 = (); };
+    (@single I2) => { /* snipped */ };
     (@single I3) => { /* snipped */ };
     (@single I4) => { /* snipped */ };
     (@single I5) => { /* snipped */ };
@@ -56,7 +56,6 @@ pub(crate) trait NodeGenerics: 'static + NotObserver {
     type R: Value;
     type BindRhs: Value;
     type I1: Value;
-    type I2: Value;
 }
 
 pub(crate) enum Kind<G: NodeGenerics> {

--- a/src/kind.rs
+++ b/src/kind.rs
@@ -28,7 +28,7 @@ macro_rules! node_generics_default {
     (@single BindLhs) => { type BindLhs = (); };
     (@single BindRhs) => { type BindRhs = (); };
     (@single B1) => { type B1 = fn(&Self::BindLhs) -> Incr<Self::BindRhs>; };
-    (@single Fold) => { type Fold = fn(Self::R, &Self::I1) -> Self::R; };
+    (@single Fold) => { /* snipped */ };
     (@single Update) => { /* snipped */ };
     (@single WithOld) => { type WithOld = fn(Option<Self::R>, &Self::I1) -> (Self::R, bool); };
     (@single FRef) => { type FRef = fn(&Self::I1) -> &Self::R; };
@@ -64,13 +64,12 @@ pub(crate) trait NodeGenerics: 'static + NotObserver {
     type I6: Value;
     type FRef: Fn(&Self::I1) -> &Self::R + NotObserver;
     type B1: FnMut(&Self::BindLhs) -> Incr<Self::BindRhs> + NotObserver;
-    type Fold: FnMut(Self::R, &Self::I1) -> Self::R + NotObserver;
     type WithOld: FnMut(Option<Self::R>, &Self::I1) -> (Self::R, bool) + NotObserver;
 }
 
 pub(crate) enum Kind<G: NodeGenerics> {
     Constant(G::R),
-    ArrayFold(array_fold::ArrayFold<G::Fold, G::I1, G::R>),
+    ArrayFold(array_fold::ArrayFold<G::I1, G::R>),
     // We have a strong reference to the Var, because (e.g.) the user's public::Var
     // may have been set and then dropped before the next stabilise().
     Var(Rc<Var<G::R>>),

--- a/src/kind.rs
+++ b/src/kind.rs
@@ -32,7 +32,7 @@ macro_rules! node_generics_default {
     (@single Update) => { type Update = fn(Self::R, &Self::I1, &Self::I1) -> Self::R; };
     (@single WithOld) => { type WithOld = fn(Option<Self::R>, &Self::I1) -> (Self::R, bool); };
     (@single FRef) => { type FRef = fn(&Self::I1) -> &Self::R; };
-    (@single Recompute) => { type Recompute = fn() -> Self::R; };
+    (@single Recompute) => { /* snipped */ };
     (@single ObsChange) => { /* snipped */ };
 
     ($($ident:ident),*) => {
@@ -74,7 +74,6 @@ pub(crate) trait NodeGenerics: 'static + NotObserver {
     type Fold: FnMut(Self::R, &Self::I1) -> Self::R + NotObserver;
     type Update: FnMut(Self::R, &Self::I1, &Self::I1) -> Self::R + NotObserver;
     type WithOld: FnMut(Option<Self::R>, &Self::I1) -> (Self::R, bool) + NotObserver;
-    type Recompute: FnMut() -> Self::R + NotObserver;
 }
 
 pub(crate) enum Kind<G: NodeGenerics> {
@@ -104,7 +103,7 @@ pub(crate) enum Kind<G: NodeGenerics> {
         // BindNode holds weak refs to both
         lhs_change: Rc<Node<bind::BindLhsChangeGen<G::B1, G::BindLhs, G::BindRhs>>>,
     },
-    Expert(expert::ExpertNode<G::R, G::Recompute>),
+    Expert(expert::ExpertNode<G::R>),
 }
 
 impl<G: NodeGenerics> Debug for Kind<G> {

--- a/src/kind.rs
+++ b/src/kind.rs
@@ -84,13 +84,12 @@ pub(crate) enum Kind<G: NodeGenerics> {
         bind: Rc<bind::BindNode<G::BindRhs>>,
     },
     BindMain {
-        casts: bind::BindMainId<G>,
-        bind: Rc<bind::BindNode<G::BindRhs>>,
+        bind: Rc<bind::BindNode<G::R>>,
         // Ownership goes
         // a Kind::BindMain holds a BindNode & the BindLhsChange
         // a Kind::BindLhsChange holds a BindNode
         // BindNode holds weak refs to both
-        lhs_change: Rc<Node<bind::BindLhsChangeGen<G::BindRhs>>>,
+        lhs_change: Rc<Node<bind::BindLhsChangeGen<G::R>>>,
     },
     Expert(expert::ExpertNode<G::R>),
 }

--- a/src/kind.rs
+++ b/src/kind.rs
@@ -20,10 +20,10 @@ macro_rules! node_generics_default {
 
     (@single I1) => { type I1 = (); };
     (@single I2) => { type I2 = (); };
-    (@single I3) => { type I3 = (); };
-    (@single I4) => { type I4 = (); };
-    (@single I5) => { type I5 = (); };
-    (@single I6) => { type I6 = (); };
+    (@single I3) => { /* snipped */ };
+    (@single I4) => { /* snipped */ };
+    (@single I5) => { /* snipped */ };
+    (@single I6) => { /* snipped */ };
 
     (@single BindLhs) => { /* snipped */ };
     (@single BindRhs) => { type BindRhs = (); };
@@ -57,10 +57,6 @@ pub(crate) trait NodeGenerics: 'static + NotObserver {
     type BindRhs: Value;
     type I1: Value;
     type I2: Value;
-    type I3: Value;
-    type I4: Value;
-    type I5: Value;
-    type I6: Value;
     type FRef: Fn(&Self::I1) -> &Self::R + NotObserver;
     type WithOld: FnMut(Option<Self::R>, &Self::I1) -> (Self::R, bool) + NotObserver;
 }
@@ -71,14 +67,14 @@ pub(crate) enum Kind<G: NodeGenerics> {
     // We have a strong reference to the Var, because (e.g.) the user's public::Var
     // may have been set and then dropped before the next stabilise().
     Var(Rc<Var<G::R>>),
-    Map(map::MapNode<G::I1, G::R>),
+    Map(map::MapNode<G::R>),
     MapWithOld(map::MapWithOld<G::WithOld, G::I1, G::R>),
     MapRef(map::MapRefNode<G::FRef, G::I1, G::R>),
-    Map2(map::Map2Node<G::I1, G::I2, G::R>),
-    Map3(map::Map3Node<G::I1, G::I2, G::I3, G::R>),
-    Map4(map::Map4Node<G::I1, G::I2, G::I3, G::I4, G::R>),
-    Map5(map::Map5Node<G::I1, G::I2, G::I3, G::I4, G::I5, G::R>),
-    Map6(map::Map6Node<G::I1, G::I2, G::I3, G::I4, G::I5, G::I6, G::R>),
+    Map2(map::Map2Node<G::R>),
+    Map3(map::Map3Node<G::R>),
+    Map4(map::Map4Node<G::R>),
+    Map5(map::Map5Node<G::R>),
+    Map6(map::Map6Node<G::R>),
     BindLhsChange {
         casts: bind::BindLhsId<G>,
         bind: Rc<bind::BindNode<G::BindRhs>>,
@@ -135,83 +131,28 @@ impl<G: NodeGenerics> Kind<G> {
                     }
                     Kind::Var(_) => write!(f, "Var<{}>", std::any::type_name::<G::R>()),
                     Kind::Map(..) => {
-                        write!(
-                            f,
-                            "Map<({}) -> {}>",
-                            std::any::type_name::<G::I1>(),
-                            std::any::type_name::<G::R>()
-                        )
+                        write!(f, "Map<(...) -> {}>", std::any::type_name::<G::R>())
                     }
                     Kind::MapWithOld(..) => {
-                        write!(
-                            f,
-                            "MapWithOld<({}) -> {}>",
-                            std::any::type_name::<G::I1>(),
-                            std::any::type_name::<G::R>()
-                        )
+                        write!(f, "MapWithOld<(...) -> {}>", std::any::type_name::<G::R>())
                     }
                     Kind::MapRef(..) => {
-                        write!(
-                            f,
-                            "MapRef<({}) -> {}>",
-                            std::any::type_name::<G::I1>(),
-                            std::any::type_name::<G::R>()
-                        )
+                        write!(f, "MapRef<(...) -> {}>", std::any::type_name::<G::R>())
                     }
                     Kind::Map2(..) => {
-                        write!(
-                            f,
-                            "Map2<({}, {}) -> {}>",
-                            std::any::type_name::<G::I1>(),
-                            std::any::type_name::<G::I2>(),
-                            std::any::type_name::<G::R>()
-                        )
+                        write!(f, "Map2<(...) -> {}>", std::any::type_name::<G::R>())
                     }
                     Kind::Map3(..) => {
-                        write!(
-                            f,
-                            "Map3<({}, {}, {}) -> {}>",
-                            std::any::type_name::<G::I1>(),
-                            std::any::type_name::<G::I2>(),
-                            std::any::type_name::<G::I3>(),
-                            std::any::type_name::<G::R>()
-                        )
+                        write!(f, "Map3<(...) -> {}>", std::any::type_name::<G::R>())
                     }
                     Kind::Map4(..) => {
-                        write!(
-                            f,
-                            "Map4<({}, {}, {}, {}) -> {}>",
-                            std::any::type_name::<G::I1>(),
-                            std::any::type_name::<G::I2>(),
-                            std::any::type_name::<G::I3>(),
-                            std::any::type_name::<G::I4>(),
-                            std::any::type_name::<G::R>()
-                        )
+                        write!(f, "Map4<(...) -> {}>", std::any::type_name::<G::R>())
                     }
                     Kind::Map5(..) => {
-                        write!(
-                            f,
-                            "Map5<({}, {}, {}, {}, {}) -> {}>",
-                            std::any::type_name::<G::I1>(),
-                            std::any::type_name::<G::I2>(),
-                            std::any::type_name::<G::I3>(),
-                            std::any::type_name::<G::I4>(),
-                            std::any::type_name::<G::I5>(),
-                            std::any::type_name::<G::R>()
-                        )
+                        write!(f, "Map5<(...) -> {}>", std::any::type_name::<G::R>())
                     }
                     Kind::Map6(..) => {
-                        write!(
-                            f,
-                            "Map6<({}, {}, {}, {}, {}, {}) -> {}>",
-                            std::any::type_name::<G::I1>(),
-                            std::any::type_name::<G::I2>(),
-                            std::any::type_name::<G::I3>(),
-                            std::any::type_name::<G::I4>(),
-                            std::any::type_name::<G::I5>(),
-                            std::any::type_name::<G::I6>(),
-                            std::any::type_name::<G::R>()
-                        )
+                        write!(f, "Map6<(...) -> {}>", std::any::type_name::<G::R>())
                     }
                     Kind::BindLhsChange { .. } => {
                         write!(f, "BindLhsChange",)

--- a/src/kind.rs
+++ b/src/kind.rs
@@ -26,7 +26,7 @@ use miny::Miny;
 
 pub(crate) enum Kind {
     Constant(Miny<dyn ValueInternal>),
-    ArrayFold(Box<dyn KindTrait>),
+    ArrayFold(miny::Miny<dyn KindTrait>),
     // We have a strong reference to the Var, because (e.g.) the user's public::Var
     // may have been set and then dropped before the next stabilise().
     Var(Rc<dyn ErasedVariable>),

--- a/src/kind.rs
+++ b/src/kind.rs
@@ -82,7 +82,6 @@ pub(crate) enum Kind<G: NodeGenerics> {
     Map5(map::Map5Node<G::R>),
     Map6(map::Map6Node<G::R>),
     BindLhsChange {
-        casts: bind::BindLhsId<G>,
         bind: Rc<bind::BindNode>,
     },
     BindMain {

--- a/src/kind.rs
+++ b/src/kind.rs
@@ -30,8 +30,8 @@ macro_rules! node_generics_default {
     (@single B1) => { /* snipped */ };
     (@single Fold) => { /* snipped */ };
     (@single Update) => { /* snipped */ };
-    (@single WithOld) => { type WithOld = fn(Option<Self::R>, &Self::I1) -> (Self::R, bool); };
-    (@single FRef) => { type FRef = fn(&Self::I1) -> &Self::R; };
+    (@single WithOld) => { /* snipped */ };
+    (@single FRef) => { /* snipped */ };
     (@single Recompute) => { /* snipped */ };
     (@single ObsChange) => { /* snipped */ };
 
@@ -57,8 +57,6 @@ pub(crate) trait NodeGenerics: 'static + NotObserver {
     type BindRhs: Value;
     type I1: Value;
     type I2: Value;
-    type FRef: Fn(&Self::I1) -> &Self::R + NotObserver;
-    type WithOld: FnMut(Option<Self::R>, &Self::I1) -> (Self::R, bool) + NotObserver;
 }
 
 pub(crate) enum Kind<G: NodeGenerics> {
@@ -68,8 +66,8 @@ pub(crate) enum Kind<G: NodeGenerics> {
     // may have been set and then dropped before the next stabilise().
     Var(Rc<Var<G::R>>),
     Map(map::MapNode<G::R>),
-    MapWithOld(map::MapWithOld<G::WithOld, G::I1, G::R>),
-    MapRef(map::MapRefNode<G::FRef, G::I1, G::R>),
+    MapWithOld(map::MapWithOld<G::R>),
+    MapRef(map::MapRefNode<G::R>),
     Map2(map::Map2Node<G::R>),
     Map3(map::Map3Node<G::R>),
     Map4(map::Map4Node<G::R>),

--- a/src/kind.rs
+++ b/src/kind.rs
@@ -2,7 +2,6 @@ use std::any::Any;
 use std::fmt::{self, Debug};
 use std::rc::Rc;
 
-use super::node::Node;
 use crate::incrsan::NotObserver;
 use crate::var::ErasedVariable;
 use crate::{Incr, NodeRef, Value};
@@ -90,7 +89,7 @@ pub(crate) enum Kind<G: NodeGenerics> {
         // a Kind::BindMain holds a BindNode & the BindLhsChange
         // a Kind::BindLhsChange holds a BindNode
         // BindNode holds weak refs to both
-        lhs_change: Rc<Node<bind::BindLhsChangeGen<G::R>>>,
+        lhs_change: NodeRef,
     },
     Expert(expert::ExpertNode<G::R>),
 }

--- a/src/kind/array_fold.rs
+++ b/src/kind/array_fold.rs
@@ -1,14 +1,12 @@
-use std::any::Any;
 use std::cell::RefCell;
 use std::fmt::{self, Debug};
 
 use miny::Miny;
 
-use super::NodeGenerics;
 use super::{Incr, Value};
 use crate::incrsan::NotObserver;
 use crate::kind::KindTrait;
-use crate::NodeRef;
+use crate::{NodeRef, ValueInternal};
 
 pub(crate) struct ArrayFold<F, I, R> {
     pub(crate) init: R,
@@ -22,7 +20,7 @@ where
     I: Value,
     R: Value,
 {
-    fn compute(&self) -> Miny<dyn Any> {
+    fn compute(&self) -> Miny<dyn ValueInternal> {
         let mut acc = self.init.clone();
         let mut f = self.fold.borrow_mut();
         acc = self.children.iter().fold(acc, |acc, x| {
@@ -48,16 +46,6 @@ where
             std::any::type_name::<R>()
         )
     }
-}
-
-impl<F, I: Value, R: Value> NodeGenerics for ArrayFold<F, I, R>
-where
-    F: 'static + NotObserver,
-{
-    type R = R;
-    node_generics_default! { I1, I2, I3, I4, I5, I6 }
-    node_generics_default! { F1, F2, F3, F4, F5, F6 }
-    node_generics_default! { B1, BindLhs, BindRhs, Update, WithOld, FRef, Recompute, ObsChange }
 }
 
 impl<F, I, R> Debug for ArrayFold<F, I, R>

--- a/src/kind/array_fold.rs
+++ b/src/kind/array_fold.rs
@@ -1,9 +1,8 @@
 use std::cell::RefCell;
 use std::fmt::{self, Debug};
 
-use miny::Miny;
-
 use super::{Incr, Value};
+use crate::boxes::{new_unsized, SmallBox};
 use crate::incrsan::NotObserver;
 use crate::kind::KindTrait;
 use crate::{NodeRef, ValueInternal};
@@ -20,14 +19,14 @@ where
     I: Value,
     R: Value,
 {
-    fn compute(&self) -> Miny<dyn ValueInternal> {
+    fn compute(&self) -> SmallBox<dyn ValueInternal> {
         let mut acc = self.init.clone();
         let mut f = self.fold.borrow_mut();
         acc = self.children.iter().fold(acc, |acc, x| {
             let v = x.node.value_as_ref().unwrap();
             f(acc, &v)
         });
-        Miny::new_unsized(acc)
+        new_unsized!(acc)
     }
     fn children_len(&self) -> usize {
         self.children.len()

--- a/src/kind/array_fold.rs
+++ b/src/kind/array_fold.rs
@@ -4,22 +4,29 @@ use std::fmt::{self, Debug};
 use super::NodeGenerics;
 use super::{Incr, Value};
 use crate::incrsan::NotObserver;
+use crate::NodeRef;
 
-pub(crate) trait FoldFunction<I, R>: FnMut(R, &I) -> R + NotObserver {}
-impl<F, I, R> FoldFunction<I, R> for F where F: FnMut(R, &I) -> R + NotObserver {}
+pub(crate) trait ArrayFoldTrait<R>: 'static + NotObserver + Debug {
+    fn compute(&self) -> R;
+    fn children_len(&self) -> usize;
+    fn iter_children_packed(&self) -> Box<dyn Iterator<Item = NodeRef> + '_>;
+    fn slow_get_child(&self, index: usize) -> NodeRef;
+    fn debug_ty(&self, f: &mut fmt::Formatter) -> fmt::Result;
+}
 
-pub(crate) struct ArrayFold<I, R> {
+pub(crate) struct ArrayFold<F, I, R> {
     pub(crate) init: R,
-    pub(crate) fold: RefCell<Box<dyn FoldFunction<I, R>>>,
+    pub(crate) fold: RefCell<F>,
     pub(crate) children: Vec<Incr<I>>,
 }
 
-impl<I, R> ArrayFold<I, R>
+impl<F, I, R> ArrayFoldTrait<R> for ArrayFold<F, I, R>
 where
+    F: FnMut(R, &I) -> R + 'static + NotObserver,
     I: Value,
     R: Value,
 {
-    pub(crate) fn compute(&self) -> R {
+    fn compute(&self) -> R {
         let acc = self.init.clone();
         let mut f = self.fold.borrow_mut();
         self.children.iter().fold(acc, |acc, x| {
@@ -27,17 +34,36 @@ where
             f(acc, &v)
         })
     }
+    fn children_len(&self) -> usize {
+        self.children.len()
+    }
+    fn iter_children_packed(&self) -> Box<dyn Iterator<Item = NodeRef> + '_> {
+        Box::new(self.children.iter().map(|x| x.node.packed()))
+    }
+    fn slow_get_child(&self, index: usize) -> NodeRef {
+        self.children[index].node.packed()
+    }
+    fn debug_ty(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(
+            f,
+            "ArrayFold<[{}] -> {}>",
+            std::any::type_name::<I>(),
+            std::any::type_name::<R>()
+        )
+    }
 }
 
-impl<I: Value, R: Value> NodeGenerics for ArrayFold<I, R> {
+impl<F, I: Value, R: Value> NodeGenerics for ArrayFold<F, I, R>
+where
+    F: 'static + NotObserver,
+{
     type R = R;
-    type I1 = I;
-    node_generics_default! { I2, I3, I4, I5, I6 }
+    node_generics_default! { I1, I2, I3, I4, I5, I6 }
     node_generics_default! { F1, F2, F3, F4, F5, F6 }
     node_generics_default! { B1, BindLhs, BindRhs, Update, WithOld, FRef, Recompute, ObsChange }
 }
 
-impl<I, R> Debug for ArrayFold<I, R>
+impl<F, I, R> Debug for ArrayFold<F, I, R>
 where
     R: Debug,
 {

--- a/src/kind/bind.rs
+++ b/src/kind/bind.rs
@@ -2,8 +2,6 @@ use std::any::Any;
 use std::cell::RefCell;
 use std::{cell::Cell, fmt};
 
-use refl::Id;
-
 use super::NodeGenerics;
 use crate::incrsan::NotObserver;
 use crate::node::NodeId;
@@ -105,15 +103,5 @@ impl fmt::Debug for BindNode {
         f.debug_struct("BindNode")
             // .field("output", &self.rhs.borrow().as_ref().map(|x| &x.node))
             .finish()
-    }
-}
-
-pub(crate) struct BindLhsId<G: NodeGenerics> {
-    pub(crate) r_unit: Id<(), G::R>,
-}
-
-impl<G: NodeGenerics> fmt::Debug for BindLhsId<G> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("BindLhsId").finish()
     }
 }

--- a/src/kind/bind.rs
+++ b/src/kind/bind.rs
@@ -3,6 +3,7 @@ use std::{cell::Cell, fmt};
 
 use crate::boxes::SmallBox;
 use crate::incrsan::NotObserver;
+use crate::node::ErasedNode;
 use crate::node::NodeId;
 use crate::scope::{BindScope, Scope};
 use crate::ValueInternal;

--- a/src/kind/bind.rs
+++ b/src/kind/bind.rs
@@ -100,8 +100,8 @@ where
     type BindRhs = R;
     /// Rhs
     type I1 = R;
-    /// BindLhsChange (a sentinel)
-    type I2 = ();
+    // BindLhsChange (a sentinel)
+    // type I2 = ();
     node_generics_default! { I3, I4, I5, I6 }
     node_generics_default! { F1, F2, F3, F4, F5, F6 }
     node_generics_default! { Fold, Update, WithOld, FRef, Recompute, ObsChange }

--- a/src/kind/bind.rs
+++ b/src/kind/bind.rs
@@ -7,7 +7,7 @@ use refl::Id;
 
 use super::NodeGenerics;
 use crate::incrsan::NotObserver;
-use crate::node::{ErasedNode, Input, Node, NodeId};
+use crate::node::{Node, NodeId};
 use crate::scope::{BindScope, Scope};
 use crate::{Incr, Value};
 use crate::{NodeRef, WeakNode};
@@ -18,10 +18,10 @@ where
 {
     pub id_lhs_change: Cell<NodeId>,
     pub lhs_change: RefCell<Weak<Node<BindLhsChangeGen<R>>>>,
-    pub main: RefCell<Weak<Node<BindNodeMainGen<R>>>>,
+    pub main: RefCell<WeakNode>,
     pub lhs: NodeRef,
     pub mapper: RefCell<Box<dyn LhsChangeFn<R>>>,
-    pub rhs: RefCell<Option<Incr<R>>>,
+    pub rhs: RefCell<Option<NodeRef>>,
     pub rhs_scope: RefCell<Scope>,
     pub all_nodes_created_on_rhs: RefCell<Vec<WeakNode>>,
 }
@@ -113,7 +113,7 @@ where
 {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         f.debug_struct("BindNode")
-            .field("output", &self.rhs.borrow().as_ref().map(|x| &x.node))
+            // .field("output", &self.rhs.borrow().as_ref().map(|x| &x.node))
             .finish()
     }
 }
@@ -130,7 +130,7 @@ impl<G: NodeGenerics> fmt::Debug for BindLhsId<G> {
 
 pub(crate) struct BindMainId<G: NodeGenerics> {
     pub(crate) rhs_r: Id<G::BindRhs, G::R>,
-    pub(crate) input_rhs_i1: Id<Input<G::BindRhs>, Input<G::I1>>,
+    // pub(crate) input_rhs_i1: Id<Input<G::BindRhs>, Input<G::I1>>,
     // pub(crate) input_lhs_i2: Id<Input<()>, Input<G::I2>>,
 }
 

--- a/src/kind/bind.rs
+++ b/src/kind/bind.rs
@@ -128,7 +128,6 @@ where
 
 pub(crate) struct BindLhsId<G: NodeGenerics> {
     pub(crate) r_unit: Id<(), G::R>,
-    pub(crate) input_lhs_i2: Id<Input<G::BindLhs>, Input<G::I2>>,
 }
 
 impl<G: NodeGenerics> fmt::Debug for BindLhsId<G> {

--- a/src/kind/bind.rs
+++ b/src/kind/bind.rs
@@ -1,8 +1,7 @@
 use std::cell::RefCell;
 use std::{cell::Cell, fmt};
 
-use miny::Miny;
-
+use crate::boxes::SmallBox;
 use crate::incrsan::NotObserver;
 use crate::node::NodeId;
 use crate::scope::{BindScope, Scope};
@@ -14,7 +13,7 @@ pub(crate) struct BindNode {
     pub lhs_change: RefCell<WeakNode>,
     pub main: RefCell<WeakNode>,
     pub lhs: NodeRef,
-    pub mapper: RefCell<Miny<dyn LhsChangeFn>>,
+    pub mapper: RefCell<SmallBox<dyn LhsChangeFn>>,
     pub rhs: RefCell<Option<NodeRef>>,
     pub rhs_scope: RefCell<Scope>,
     pub all_nodes_created_on_rhs: RefCell<Vec<WeakNode>>,

--- a/src/kind/bind.rs
+++ b/src/kind/bind.rs
@@ -127,18 +127,3 @@ impl<G: NodeGenerics> fmt::Debug for BindLhsId<G> {
         f.debug_struct("BindLhsId").finish()
     }
 }
-
-pub(crate) struct BindMainId<G: NodeGenerics> {
-    pub(crate) rhs_r: Id<G::BindRhs, G::R>,
-    // pub(crate) input_rhs_i1: Id<Input<G::BindRhs>, Input<G::I1>>,
-    // pub(crate) input_lhs_i2: Id<Input<()>, Input<G::I2>>,
-}
-
-impl<G: NodeGenerics> fmt::Debug for BindMainId<G> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("BindMainId")
-            .field("d_eq_r", &self.rhs_r)
-            // .field("input_lhs_change_unit", &self.input_lhs_i2)
-            .finish()
-    }
-}

--- a/src/kind/bind.rs
+++ b/src/kind/bind.rs
@@ -1,6 +1,8 @@
 use std::cell::RefCell;
 use std::{cell::Cell, fmt};
 
+use miny::Miny;
+
 use crate::incrsan::NotObserver;
 use crate::node::NodeId;
 use crate::scope::{BindScope, Scope};
@@ -12,7 +14,7 @@ pub(crate) struct BindNode {
     pub lhs_change: RefCell<WeakNode>,
     pub main: RefCell<WeakNode>,
     pub lhs: NodeRef,
-    pub mapper: RefCell<Box<dyn LhsChangeFn>>,
+    pub mapper: RefCell<Miny<dyn LhsChangeFn>>,
     pub rhs: RefCell<Option<NodeRef>>,
     pub rhs_scope: RefCell<Scope>,
     pub all_nodes_created_on_rhs: RefCell<Vec<WeakNode>>,

--- a/src/kind/bind.rs
+++ b/src/kind/bind.rs
@@ -79,7 +79,7 @@ where
     // type BindLhs = T;
     type BindRhs = R;
     // swap order so we can use as_parent with I1
-    type I1 = ();
+    // type I1 = ();
     // type I2 = T;
     node_generics_default! { I2, I3, I4, I5, I6 }
     node_generics_default! { F1, F2, F3, F4, F5, F6 }
@@ -98,8 +98,8 @@ where
     type R = R;
     // type BindLhs = T;
     type BindRhs = R;
-    /// Rhs
-    type I1 = R;
+    // Rhs
+    // type I1 = R;
     // BindLhsChange (a sentinel)
     // type I2 = ();
     node_generics_default! { I3, I4, I5, I6 }

--- a/src/kind/bind.rs
+++ b/src/kind/bind.rs
@@ -1,23 +1,19 @@
 use std::any::Any;
 use std::cell::RefCell;
-use std::rc::Weak;
 use std::{cell::Cell, fmt};
 
 use refl::Id;
 
 use super::NodeGenerics;
 use crate::incrsan::NotObserver;
-use crate::node::{Node, NodeId};
+use crate::node::NodeId;
 use crate::scope::{BindScope, Scope};
 use crate::Value;
 use crate::{NodeRef, WeakNode};
 
-pub(crate) struct BindNode<R>
-where
-    R: Value,
-{
+pub(crate) struct BindNode {
     pub id_lhs_change: Cell<NodeId>,
-    pub lhs_change: RefCell<Weak<Node<BindLhsChangeGen<R>>>>,
+    pub lhs_change: RefCell<WeakNode>,
     pub main: RefCell<WeakNode>,
     pub lhs: NodeRef,
     pub mapper: RefCell<Box<dyn LhsChangeFn>>,
@@ -26,10 +22,7 @@ where
     pub all_nodes_created_on_rhs: RefCell<Vec<WeakNode>>,
 }
 
-impl<R> BindScope for BindNode<R>
-where
-    R: Value,
-{
+impl BindScope for BindNode {
     fn id(&self) -> NodeId {
         self.id_lhs_change.get()
     }
@@ -50,7 +43,7 @@ where
     fn height(&self) -> i32 {
         let lhs_change_ = self.lhs_change.borrow();
         let lhs_change = lhs_change_.upgrade().unwrap();
-        lhs_change.height.get()
+        lhs_change.height()
     }
     fn add_node(&self, node: WeakNode) {
         tracing::info!(
@@ -107,10 +100,7 @@ where
     node_generics_default! { Fold, Update, WithOld, FRef, Recompute, ObsChange }
 }
 
-impl<R> fmt::Debug for BindNode<R>
-where
-    R: Value,
-{
+impl fmt::Debug for BindNode {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         f.debug_struct("BindNode")
             // .field("output", &self.rhs.borrow().as_ref().map(|x| &x.node))

--- a/src/kind/bind.rs
+++ b/src/kind/bind.rs
@@ -1,12 +1,10 @@
-use std::any::Any;
 use std::cell::RefCell;
 use std::{cell::Cell, fmt};
 
-use super::NodeGenerics;
 use crate::incrsan::NotObserver;
 use crate::node::NodeId;
 use crate::scope::{BindScope, Scope};
-use crate::Value;
+use crate::ValueInternal;
 use crate::{NodeRef, WeakNode};
 
 pub(crate) struct BindNode {
@@ -54,49 +52,11 @@ impl BindScope for BindNode {
     }
 }
 
-pub(crate) struct BindLhsChangeGen<R> {
-    _phantom: std::marker::PhantomData<R>,
-}
-
-pub(crate) trait LhsChangeFn: FnMut(&dyn Any) -> NodeRef + 'static + NotObserver {}
-impl<F> LhsChangeFn for F where F: FnMut(&dyn Any) -> NodeRef + 'static + NotObserver {}
-
-impl<R> NodeGenerics for BindLhsChangeGen<R>
-where
-    R: Value,
+pub(crate) trait LhsChangeFn:
+    FnMut(&dyn ValueInternal) -> NodeRef + 'static + NotObserver
 {
-    // lhs change's Node stores () nothing. just a sentinel.
-    type R = ();
-    // type BindLhs = T;
-    type BindRhs = R;
-    // swap order so we can use as_parent with I1
-    // type I1 = ();
-    // type I2 = T;
-    node_generics_default! { I2, I3, I4, I5, I6 }
-    node_generics_default! { F1, F2, F3, F4, F5, F6 }
-    node_generics_default! { Fold, Update, WithOld, FRef, Recompute, ObsChange }
 }
-
-pub(crate) struct BindNodeMainGen<R> {
-    _phantom: std::marker::PhantomData<R>,
-}
-
-impl<R> NodeGenerics for BindNodeMainGen<R>
-where
-    R: Value,
-{
-    // We copy the output of the Rhs
-    type R = R;
-    // type BindLhs = T;
-    type BindRhs = R;
-    // Rhs
-    // type I1 = R;
-    // BindLhsChange (a sentinel)
-    // type I2 = ();
-    node_generics_default! { I3, I4, I5, I6 }
-    node_generics_default! { F1, F2, F3, F4, F5, F6 }
-    node_generics_default! { Fold, Update, WithOld, FRef, Recompute, ObsChange }
-}
+impl<F> LhsChangeFn for F where F: FnMut(&dyn ValueInternal) -> NodeRef + 'static + NotObserver {}
 
 impl fmt::Debug for BindNode {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {

--- a/src/kind/bind.rs
+++ b/src/kind/bind.rs
@@ -9,7 +9,7 @@ use super::NodeGenerics;
 use crate::incrsan::NotObserver;
 use crate::node::{Node, NodeId};
 use crate::scope::{BindScope, Scope};
-use crate::{Incr, Value};
+use crate::Value;
 use crate::{NodeRef, WeakNode};
 
 pub(crate) struct BindNode<R>
@@ -20,7 +20,7 @@ where
     pub lhs_change: RefCell<Weak<Node<BindLhsChangeGen<R>>>>,
     pub main: RefCell<WeakNode>,
     pub lhs: NodeRef,
-    pub mapper: RefCell<Box<dyn LhsChangeFn<R>>>,
+    pub mapper: RefCell<Box<dyn LhsChangeFn>>,
     pub rhs: RefCell<Option<NodeRef>>,
     pub rhs_scope: RefCell<Scope>,
     pub all_nodes_created_on_rhs: RefCell<Vec<WeakNode>>,
@@ -67,8 +67,8 @@ pub(crate) struct BindLhsChangeGen<R> {
     _phantom: std::marker::PhantomData<R>,
 }
 
-pub(crate) trait LhsChangeFn<R>: FnMut(&dyn Any) -> Incr<R> + 'static + NotObserver {}
-impl<F, R> LhsChangeFn<R> for F where F: FnMut(&dyn Any) -> Incr<R> + 'static + NotObserver {}
+pub(crate) trait LhsChangeFn: FnMut(&dyn Any) -> NodeRef + 'static + NotObserver {}
+impl<F> LhsChangeFn for F where F: FnMut(&dyn Any) -> NodeRef + 'static + NotObserver {}
 
 impl<R> NodeGenerics for BindLhsChangeGen<R>
 where

--- a/src/kind/expert.rs
+++ b/src/kind/expert.rs
@@ -7,7 +7,7 @@ use std::{
 
 use super::NodeGenerics;
 use crate::incrsan::NotObserver;
-use crate::node::ErasedIncremental;
+use crate::node::ErasedNode;
 use crate::{CellIncrement, Incr, NodeRef, Value};
 
 pub(crate) trait ExpertEdge: Any + NotObserver {
@@ -15,7 +15,7 @@ pub(crate) trait ExpertEdge: Any + NotObserver {
     fn on_change(&self);
     fn packed(&self) -> NodeRef;
     fn index_cell(&self) -> &Cell<Option<i32>>;
-    fn erased_input(&self) -> &dyn ErasedIncremental;
+    fn erased_input(&self) -> &dyn ErasedNode;
 }
 
 pub(crate) type PackedEdge = Rc<dyn ExpertEdge>;
@@ -61,8 +61,8 @@ impl<T: Value> ExpertEdge for Edge<T> {
         &self.index
     }
 
-    fn erased_input(&self) -> &dyn ErasedIncremental {
-        self.child.node.erased_input()
+    fn erased_input(&self) -> &dyn ErasedNode {
+        self.child.node.erased()
     }
 }
 

--- a/src/kind/expert.rs
+++ b/src/kind/expert.rs
@@ -4,10 +4,8 @@ use std::{
     rc::Rc,
 };
 
-use crate::{
-    boxes::{new_unsized, SmallBox},
-    node::ErasedNode,
-};
+use crate::boxes::{new_unsized, SmallBox};
+use crate::node::Node;
 use crate::{incrsan::NotObserver, ValueInternal};
 use crate::{CellIncrement, Incr, NodeRef, Value};
 
@@ -16,7 +14,7 @@ pub(crate) trait ExpertEdge: Any + NotObserver {
     fn on_change(&self);
     fn packed(&self) -> NodeRef;
     fn index_cell(&self) -> &Cell<Option<i32>>;
-    fn erased_input(&self) -> &dyn ErasedNode;
+    fn erased_input(&self) -> &Node;
 }
 
 pub(crate) type PackedEdge = Rc<dyn ExpertEdge>;
@@ -62,7 +60,7 @@ impl<T: Value> ExpertEdge for Edge<T> {
         &self.index
     }
 
-    fn erased_input(&self) -> &dyn ErasedNode {
+    fn erased_input(&self) -> &Node {
         self.child.node.erased()
     }
 }

--- a/src/kind/expert.rs
+++ b/src/kind/expert.rs
@@ -18,10 +18,7 @@ pub(crate) trait ExpertEdge: Any + NotObserver {
     fn erased_input(&self) -> &dyn ErasedIncremental;
 }
 
-pub(crate) trait IsEdge: ExpertEdge + Any {}
-impl<T> IsEdge for T where T: ExpertEdge + Any {}
-
-pub(crate) type PackedEdge = Rc<dyn IsEdge>;
+pub(crate) type PackedEdge = Rc<dyn ExpertEdge>;
 
 #[cfg(not(feature = "nightly-incrsan"))]
 type BoxedOnChange<T> = Box<dyn FnMut(&T)>;

--- a/src/kind/expert.rs
+++ b/src/kind/expert.rs
@@ -1,5 +1,5 @@
 use std::{
-    any::{Any, TypeId},
+    any::Any,
     cell::{Cell, RefCell},
     marker::PhantomData,
     rc::Rc,
@@ -16,7 +16,6 @@ pub(crate) trait ExpertEdge: Any + NotObserver {
     fn packed(&self) -> NodeRef;
     fn index_cell(&self) -> &Cell<Option<i32>>;
     fn erased_input(&self) -> &dyn ErasedIncremental;
-    fn edge_input_type_id(&self) -> TypeId;
 }
 
 pub(crate) trait IsEdge: ExpertEdge + Any {}
@@ -68,10 +67,6 @@ impl<T: Value> ExpertEdge for Edge<T> {
     fn erased_input(&self) -> &dyn ErasedIncremental {
         self.child.node.erased_input()
     }
-
-    fn edge_input_type_id(&self) -> TypeId {
-        TypeId::of::<T>()
-    }
 }
 
 pub(crate) struct ExpertNode<T, F, ObsChange> {
@@ -118,16 +113,6 @@ where
     }
     pub(crate) fn decr_invalid_children(&self) {
         self.num_invalid_children.increment();
-    }
-
-    pub(crate) fn expert_input_type_id(&self, index_of_child_in_parent: i32) -> TypeId {
-        let borrow_span = tracing::debug_span!("expert.children.borrow() in expert_input_type_id");
-        borrow_span.in_scope(|| {
-            let children = self.children.borrow();
-            assert!(index_of_child_in_parent >= 0);
-            let edge = &children[index_of_child_in_parent as usize];
-            edge.edge_input_type_id()
-        })
     }
 
     pub(crate) fn make_stale(&self) -> MakeStale {

--- a/src/kind/map.rs
+++ b/src/kind/map.rs
@@ -24,13 +24,12 @@ where
     F: Fn(&T) -> &R + 'static + NotObserver,
 {
     type R = R;
-    type BindLhs = ();
-    type BindRhs = ();
     type I1 = T;
     type FRef = F;
     node_generics_default! { I2, I3, I4, I5, I6 }
     node_generics_default! { F1, F2, F3, F4, F5, F6 }
     node_generics_default! { B1, Fold, Update, WithOld, Recompute, ObsChange }
+    node_generics_default! { BindLhs, BindRhs }
 }
 
 impl<F, T, R> fmt::Debug for MapRefNode<F, T, R>

--- a/src/kind/map.rs
+++ b/src/kind/map.rs
@@ -285,17 +285,21 @@ map_node! {
     }
 }
 
-pub(crate) trait FWithOld<R>:
-    FnMut(Option<R>, &dyn Any) -> (R, bool) + 'static + NotObserver
+pub(crate) trait FWithOld:
+    FnMut(Option<miny::Miny<dyn Any>>, &dyn Any) -> (miny::Miny<dyn Any>, bool) + 'static + NotObserver
 {
 }
-impl<F, R> FWithOld<R> for F where F: FnMut(Option<R>, &dyn Any) -> (R, bool) + 'static + NotObserver
-{}
+impl<F> FWithOld for F where
+    F: FnMut(Option<miny::Miny<dyn Any>>, &dyn Any) -> (miny::Miny<dyn Any>, bool)
+        + 'static
+        + NotObserver
+{
+}
 
 /// Lets you dismantle the old R for parts.
 pub(crate) struct MapWithOld<R> {
     pub input: NodeRef,
-    pub mapper: RefCell<Box<dyn FWithOld<R>>>,
+    pub mapper: RefCell<Box<dyn FWithOld>>,
     pub _p: PhantomData<R>,
 }
 

--- a/src/kind/map.rs
+++ b/src/kind/map.rs
@@ -78,6 +78,7 @@ macro_rules! map_node {
          }
      > {
          default < $($d:ident),* >,
+         $(#[$method_meta:meta])*
          impl Incr::$methodname:ident, Kind::$kind:ident
      }) => {
         $vis struct $mapnode <$t1, $($t,)* $r>
@@ -111,9 +112,7 @@ macro_rules! map_node {
             }
         }
         impl<$t1: Value> Incr<$t1> {
-            /// Like [Incr::map] and [Incr::map2], but with more input incrementals.
-            ///
-            /// If you don't feel like counting, try using the `(i1 % i2 % ...).map((|_, _, ...| ...))` syntax.
+            $(#[$method_meta])*
             pub fn $methodname<$fparam, $($t2,)* $r>(&self, $($tfield: &Incr<$t>,)* f: $fparam) -> Incr<R>
             where
                 $($t: Value,)*
@@ -140,6 +139,16 @@ macro_rules! map_node {
     };
 }
 
+macro_rules! default_doc {
+    () => {
+        r#"
+Like [Incr::map] and [Incr::map2], but with more input incrementals.
+
+If you don't feel like counting, try using the `(i1 % i2 % ...).map(|_, _, ...| ...)` syntax.
+"#
+    };
+}
+
 map_node! {
     pub(crate) struct MapNode<
         inputs {
@@ -148,6 +157,26 @@ map_node! {
         fn { mapper: F1(..) -> R, }
     > {
         default < F2, F3, F4, F5, F6, I2, I3, I4, I5, I6 >,
+        /// Takes an incremental (self), and produces a new incremental whose value
+        /// is the result of applying a function `f` to the first value.
+        ///
+        /// ## Example
+        ///
+        /// ```
+        /// # use incremental::*;
+        /// let state = IncrState::new();
+        /// let var = state.var(20);
+        ///
+        /// // produce a new incremental that adds ten
+        /// let plus10 = var.map(|x| *x + 10);
+        ///
+        /// let observer = plus10.observe();
+        /// state.stabilise();
+        /// assert_eq!(observer.value(), 30);
+        /// var.set(400);
+        /// state.stabilise();
+        /// assert_eq!(observer.value(), 410);
+        /// ```
         impl Incr::map, Kind::Map
     }
 }
@@ -167,6 +196,15 @@ map_node! {
         fn { mapper: F2(.., T2) -> R, }
     > {
         default < F1, F3, F4, F5, F6, I3, I4, I5, I6 >,
+        /// Like [Incr::map], but with two inputs.
+        ///
+        /// ```
+        /// # use incremental::*;
+        /// let state = IncrState::new();
+        /// let v1 = state.var(1);
+        /// let v2 = state.var(1);
+        /// let add = v1.map2(&v2, |a, b| *a + *b);
+        /// ```
         impl Incr::map2, Kind::Map2
     }
 }
@@ -181,6 +219,7 @@ map_node! {
         fn { mapper: F3(.., T2, T3) -> R, }
     > {
         default < F1, F2, F4, F5, F6, I4, I5, I6 >,
+        #[doc = default_doc!()]
         impl Incr::map3, Kind::Map3
     }
 }
@@ -196,6 +235,7 @@ map_node! {
         fn { mapper: F4(.., T2, T3, T4) -> R, }
     > {
         default < F1, F2, F3, F5, F6, I5, I6 >,
+        #[doc = default_doc!()]
         impl Incr::map4, Kind::Map4
     }
 }
@@ -212,6 +252,7 @@ map_node! {
         fn { mapper: F5(.., T2, T3, T4, T5) -> R, }
     > {
         default < F1, F2, F3, F4, F6, I6 >,
+        #[doc = default_doc!()]
         impl Incr::map5, Kind::Map5
     }
 }
@@ -229,6 +270,7 @@ map_node! {
         fn { mapper: F6(.., T2, T3, T4, T5, T6) -> R, }
     > {
         default < F1, F2, F3, F4, F5 >,
+        #[doc = default_doc!()]
         impl Incr::map6, Kind::Map6
     }
 }

--- a/src/kind/map.rs
+++ b/src/kind/map.rs
@@ -8,13 +8,14 @@ use crate::incrsan::NotObserver;
 use crate::Value;
 use crate::{Incr, NodeRef};
 
-pub(crate) trait FRef<R>: Fn(&dyn Any) -> &R + 'static + NotObserver {}
-impl<F, R> FRef<R> for F where F: Fn(&dyn Any) -> &R + 'static + NotObserver {}
+pub(crate) trait FRef: (Fn(&dyn Any) -> &dyn Any) + 'static + NotObserver {}
+impl<F> FRef for F where F: (Fn(&dyn Any) -> &dyn Any) + 'static + NotObserver {}
 
 pub(crate) struct MapRefNode<R> {
     pub(crate) input: NodeRef,
-    pub(crate) mapper: Box<dyn FRef<R>>,
+    pub(crate) mapper: Box<dyn FRef>,
     pub(crate) did_change: Cell<bool>,
+    pub(crate) phantom: PhantomData<fn() -> R>,
 }
 
 impl<R> NodeGenerics for MapRefNode<R>

--- a/src/kind/map.rs
+++ b/src/kind/map.rs
@@ -112,7 +112,10 @@ macro_rules! map_node {
         }
         impl<$t1: Value> Incr<$t1> {
             $(#[$method_meta])*
-            pub fn $methodname<$fparam, $($t2,)* $r>(&self, $($tfield: &Incr<$t>,)* f: $fparam) -> Incr<R>
+            pub fn $methodname<$fparam, $($t2,)* $r>(
+                &self,
+                $($tfield: &Incr<$t>,)*
+                f: $fparam) -> Incr<R>
             where
                 $($t: Value,)*
                 $r: Value,

--- a/src/kind/map.rs
+++ b/src/kind/map.rs
@@ -70,7 +70,11 @@ macro_rules! map_node {
         $vis struct $mapnode {
             $vis $tfield1: crate::NodeRef,
             $($vis $tfield: crate::NodeRef,)*
-            $vis $ffield: RefCell<$crate::boxes::SmallBox<dyn FnMut(&dyn $crate::ValueInternal, $(&map_node!(@any $t2),)*) -> $crate::boxes::SmallBox<dyn $crate::ValueInternal>>>,
+            $vis $ffield: RefCell<$fparam>,
+        }
+
+        $crate::incrsan::not_observer_boxed_trait! {
+            pub(crate) type $fparam = crate::boxes::SmallBox<dyn (FnMut(&dyn $crate::ValueInternal, $(&map_node!(@any $t2),)*) -> $crate::boxes::SmallBox<dyn $crate::ValueInternal>)>;
         }
 
         impl fmt::Debug for $mapnode

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,8 @@
 #![cfg_attr(feature = "nightly-incrsan", feature(negative_impls))]
 #![cfg_attr(feature = "nightly-incrsan", feature(auto_traits))]
 
+mod boxes;
+
 mod adjust_heights_heap;
 mod cutoff;
 mod incr;
@@ -22,6 +24,7 @@ mod syntax;
 mod var;
 
 mod public;
+use boxes::SmallBox;
 pub use public::*;
 
 use fmt::Debug;
@@ -51,7 +54,7 @@ where
 /// (Clone and PartialEq include Self types).
 pub(crate) trait ValueInternal: Debug + NotObserver + 'static + Any {
     fn as_any(&self) -> &dyn Any;
-    fn clone_any(&self) -> miny::Miny<dyn ValueInternal>;
+    fn clone_any(&self) -> SmallBox<dyn ValueInternal>;
 }
 impl<T> ValueInternal for T
 where
@@ -60,8 +63,8 @@ where
     fn as_any(&self) -> &dyn Any {
         self
     }
-    fn clone_any(&self) -> miny::Miny<dyn ValueInternal> {
-        miny::Miny::new_unsized(self.clone())
+    fn clone_any(&self) -> SmallBox<dyn ValueInternal> {
+        boxes::new_unsized!(self.clone())
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,7 +34,6 @@ use std::fmt;
 use std::rc::{Rc, Weak};
 
 use self::incrsan::NotObserver;
-use self::node::ErasedNode;
 
 /// Trait alias for `Debug + Clone + 'static`
 pub trait Value: Debug + Clone + PartialEq + NotObserver + 'static + Any {
@@ -68,8 +67,8 @@ where
     }
 }
 
-pub(crate) type NodeRef = Rc<dyn ErasedNode>;
-pub(crate) type WeakNode = Weak<dyn ErasedNode>;
+pub(crate) type NodeRef = Rc<node::Node>;
+pub(crate) type WeakNode = Weak<node::Node>;
 
 pub trait Invariant {
     fn invariant(&self);

--- a/src/node.rs
+++ b/src/node.rs
@@ -1477,14 +1477,17 @@ impl Node {
         .is_break()
     }
     fn find_child(&self, pred: &dyn Fn(i32, &NodeRef) -> bool) -> Option<NodeRef> {
-        self.try_fold_children((), |(), ix, child| {
+        let output = self.try_fold_children((), |(), ix, child| {
             if pred(ix, &child) {
                 ControlFlow::Break(child)
             } else {
                 ControlFlow::Continue(())
             }
-        })
-        .break_value()
+        });
+        match output {
+            ControlFlow::Continue(..) => None,
+            ControlFlow::Break(x) => Some(x),
+        }
     }
     fn try_fold_children<B, R>(
         &self,

--- a/src/node.rs
+++ b/src/node.rs
@@ -17,7 +17,7 @@ use super::CellIncrement;
 use super::{NodeRef, WeakNode};
 use crate::boxes::{new_unsized, SmallBox};
 use crate::cutoff::ErasedCutoff;
-use crate::incrsan::NotObserver;
+use crate::incrsan::{not_observer_boxed_trait, NotObserver};
 use crate::internal_observer::ErasedObserver;
 use crate::node_update::{ErasedOnUpdateHandler, OnUpdateHandler};
 use crate::{Value, ValueInternal};
@@ -104,10 +104,9 @@ pub(crate) struct Node {
     pub graphviz_user_data: RefCell<Option<BoxedDebugData>>,
 }
 
-#[cfg(not(feature = "nightly-incrsan"))]
-type BoxedDebugData = Box<dyn Debug>;
-#[cfg(feature = "nightly-incrsan")]
-type BoxedDebugData = Box<dyn Debug + NotObserver>;
+not_observer_boxed_trait! {
+    type BoxedDebugData = Box<dyn (Debug)>;
+}
 
 /// Recall that parents and children feel a bit backwards in incremental.
 /// A child == an input of self. A parent == a node derived from self.

--- a/src/node.rs
+++ b/src/node.rs
@@ -719,11 +719,8 @@ impl<G: NodeGenerics> ErasedNode for Node<G> {
                     let rhs = f(&*lhs);
                     *state.current_scope.borrow_mut() = old_scope;
                     // Check that the returned RHS node is from the same world.
-                    assert!(crate::weak_thin_ptr_eq(
-                        rhs.node.weak_state(),
-                        &state.weak_self
-                    ));
-                    rhs.node.packed()
+                    assert!(crate::weak_thin_ptr_eq(rhs.weak_state(), &state.weak_self));
+                    rhs
                 };
 
                 // TODO: let mut old_rhs = bind.rhs.borrow_mut().replace(rhs.clone());

--- a/src/node.rs
+++ b/src/node.rs
@@ -9,7 +9,7 @@ use std::rc::Weak;
 use super::adjust_heights_heap::AdjustHeightsHeap;
 use super::cutoff::Cutoff;
 use super::internal_observer::{InternalObserver, ObserverId};
-use super::kind::expert::{Invalid, IsEdge, MakeStale, PackedEdge};
+use super::kind::expert::{ExpertEdge, Invalid, MakeStale, PackedEdge};
 use super::kind::{self, Kind, NodeGenerics};
 use super::node_update::NodeUpdateDelayed;
 use super::scope::Scope;
@@ -390,7 +390,7 @@ pub(crate) trait ErasedNode: Debug + NotObserver {
         child2: &NodeRef,
         child2_index: i32,
     );
-    fn expert_remove_child(&self, packed_edge: &dyn IsEdge, child_index: i32, state: &State);
+    fn expert_remove_child(&self, packed_edge: &dyn ExpertEdge, child_index: i32, state: &State);
     fn state_opt(&self) -> Option<Rc<State>>;
     fn state(&self) -> Rc<State>;
     fn weak(&self) -> WeakNode;
@@ -430,7 +430,7 @@ pub(crate) trait ErasedNode: Debug + NotObserver {
 
     fn expert_make_stale(&self);
     fn expert_add_dependency(&self, packed_edge: PackedEdge);
-    fn expert_remove_dependency(&self, dyn_edge: &dyn IsEdge);
+    fn expert_remove_dependency(&self, dyn_edge: &dyn ExpertEdge);
 
     fn child_changed(
         &self,
@@ -1305,7 +1305,7 @@ impl<G: NodeGenerics> ErasedNode for Node<G> {
         }
     }
 
-    fn expert_remove_dependency(&self, dyn_edge: &dyn IsEdge) {
+    fn expert_remove_dependency(&self, dyn_edge: &dyn ExpertEdge) {
         let Some(Kind::Expert(expert)) = self.kind() else {
             return;
         };
@@ -1386,7 +1386,7 @@ impl<G: NodeGenerics> ErasedNode for Node<G> {
         parent_pci.my_parent_index_in_child_at_index[child_index2 as usize] = index_of_parent_in_child1;
     }
 
-    fn expert_remove_child(&self, dyn_edge: &dyn IsEdge, child_index: i32, state: &State) {
+    fn expert_remove_child(&self, dyn_edge: &dyn ExpertEdge, child_index: i32, state: &State) {
         let child = dyn_edge.erased_input();
         child.remove_parent(child_index, self);
         child.check_if_unnecessary(state);

--- a/src/node.rs
+++ b/src/node.rs
@@ -471,7 +471,7 @@ impl<G: NodeGenerics> ErasedNode for Node<G> {
         };
         match kind {
             Kind::Var(var) => {
-                let set_at = var.set_at.get();
+                let set_at = var.set_at();
                 let recomputed_at = self.recomputed_at.get();
                 set_at > recomputed_at
             }
@@ -636,10 +636,7 @@ impl<G: NodeGenerics> ErasedNode for Node<G> {
                 self.maybe_change_value(Miny::new_unsized(new_value), state)
             }
             Kind::Var(var) => {
-                let new_value = {
-                    let value = var.value.borrow();
-                    Miny::new_unsized(value.clone())
-                };
+                let new_value = var.compute();
                 self.maybe_change_value(new_value, state)
             }
             Kind::Constant(v) => {

--- a/src/node.rs
+++ b/src/node.rs
@@ -194,7 +194,9 @@ impl<G: NodeGenerics> ErasedIncremental for Node<G> {
     }
 }
 
-pub(crate) trait Incremental<R>: ErasedNode + Debug + NotObserver {
+pub(crate) trait Incremental<R>:
+    ErasedNode + ErasedIncremental + Debug + NotObserver
+{
     fn as_input(&self) -> Input<R>;
     fn erased_input(&self) -> &dyn ErasedIncremental;
     fn latest(&self) -> R;

--- a/src/node.rs
+++ b/src/node.rs
@@ -43,7 +43,15 @@ pub(crate) struct Node<G: NodeGenerics> {
     // {{{
     /// The time at which we were last recomputed. -1 if never.
     pub recomputed_at: Cell<StabilisationNum>,
-    pub value_opt: RefCell<Option<Miny<G::R>>>,
+
+    // miny::Miny<dyn Any> for e.g. a u32, does not allocate & is stored inline
+    // - sizeof u32 is <= usize (on most machines)
+    // - the trait object metadata is also a usize
+    //   (it's a vtable pointer), and is stored inline in Miny
+    // - it is not NonZero like a pointer, so Option takes space
+    // - RefCell also takes space, but optimizing the internal mutability of Node
+    //   will require more analysis of which fields are used at the same time
+    pub value_opt: RefCell<Option<Miny<dyn Any>>>,
     /// We use this flag instead of making kind mutable with an Invalid variant. That makes it much
     /// easier to implement `value_as_ref` for `Kind::MapRef`.
     pub is_valid: Cell<bool>,
@@ -304,7 +312,7 @@ impl<G: NodeGenerics> Incremental<G::R> for Node<G> {
             return mapped;
         }
         let v = self.value_opt.borrow();
-        Ref::filter_map(v, |o| o.as_deref()).ok()
+        Ref::filter_map(v, |o| o.as_deref().and_then(|x| x.downcast_ref())).ok()
     }
     fn constant(&self) -> Option<&G::R> {
         if let Some(Kind::Constant(value)) = self.kind() {
@@ -750,16 +758,16 @@ impl<G: NodeGenerics> ErasedNode for Node<G> {
                     let input = map.input.value_as_ref().unwrap();
                     f(&input)
                 };
-                self.maybe_change_value(Miny::new(new_value), state)
+                self.maybe_change_value(Miny::new_unsized(new_value), state)
             }
             Kind::Var(var) => {
                 let new_value = {
                     let value = var.value.borrow();
-                    Miny::new(value.clone())
+                    Miny::new_unsized(value.clone())
                 };
                 self.maybe_change_value(new_value, state)
             }
-            Kind::Constant(v) => self.maybe_change_value(Miny::new(v.clone()), state),
+            Kind::Constant(v) => self.maybe_change_value(Miny::new_unsized(v.clone()), state),
             Kind::MapRef(mapref) => {
                 // don't run child_changed on our parents, because we already did that in OUR child_changed.
                 self.value_opt.replace(None);
@@ -771,9 +779,12 @@ impl<G: NodeGenerics> ErasedNode for Node<G> {
                 let (new_value, did_change) = {
                     let mut current_value = self.value_opt.borrow_mut();
                     tracing::trace!("<- old: {current_value:?}");
-                    f(current_value.take().map(Miny::into_inner), &input)
+                    f(
+                        current_value.take().and_then(|x| Miny::downcast(x).ok()),
+                        &input,
+                    )
                 };
-                self.value_opt.replace(Some(Miny::new(new_value)));
+                self.value_opt.replace(Some(Miny::new_unsized(new_value)));
                 self.maybe_change_value_manual(None, did_change, true, state)
             }
             Kind::Map2(map2) => {
@@ -781,7 +792,7 @@ impl<G: NodeGenerics> ErasedNode for Node<G> {
                 let i2 = map2.two.value_as_ref().unwrap();
                 let mut f = map2.mapper.borrow_mut();
                 let new_value = f(&i1, &i2);
-                self.maybe_change_value(Miny::new(new_value), state)
+                self.maybe_change_value(Miny::new_unsized(new_value), state)
             }
             Kind::Map3(map) => {
                 let i1 = map.one.value_as_ref().unwrap();
@@ -789,7 +800,7 @@ impl<G: NodeGenerics> ErasedNode for Node<G> {
                 let i3 = map.three.value_as_ref().unwrap();
                 let mut f = map.mapper.borrow_mut();
                 let new_value = f(&i1, &i2, &i3);
-                self.maybe_change_value(Miny::new(new_value), state)
+                self.maybe_change_value(Miny::new_unsized(new_value), state)
             }
             Kind::Map4(map) => {
                 let i1 = map.one.value_as_ref().unwrap();
@@ -798,7 +809,7 @@ impl<G: NodeGenerics> ErasedNode for Node<G> {
                 let i4 = map.four.value_as_ref().unwrap();
                 let mut f = map.mapper.borrow_mut();
                 let new_value = f(&i1, &i2, &i3, &i4);
-                self.maybe_change_value(Miny::new(new_value), state)
+                self.maybe_change_value(Miny::new_unsized(new_value), state)
             }
             Kind::Map5(map) => {
                 let i1 = map.one.value_as_ref().unwrap();
@@ -808,7 +819,7 @@ impl<G: NodeGenerics> ErasedNode for Node<G> {
                 let i5 = map.five.value_as_ref().unwrap();
                 let mut f = map.mapper.borrow_mut();
                 let new_value = f(&i1, &i2, &i3, &i4, &i5);
-                self.maybe_change_value(Miny::new(new_value), state)
+                self.maybe_change_value(Miny::new_unsized(new_value), state)
             }
             Kind::Map6(map) => {
                 let i1 = map.one.value_as_ref().unwrap();
@@ -819,7 +830,7 @@ impl<G: NodeGenerics> ErasedNode for Node<G> {
                 let i6 = map.six.value_as_ref().unwrap();
                 let mut f = map.mapper.borrow_mut();
                 let new_value = f(&i1, &i2, &i3, &i4, &i5, &i6);
-                self.maybe_change_value(Miny::new(new_value), state)
+                self.maybe_change_value(Miny::new_unsized(new_value), state)
             }
             Kind::BindLhsChange { casts, bind } => {
                 // leaves an empty vec for next time
@@ -879,13 +890,13 @@ impl<G: NodeGenerics> ErasedNode for Node<G> {
                 /* [node] was valid at the start of the [Bind_lhs_change] branch, and invalidation
                 only visits higher nodes, so [node] is still valid. */
                 debug_assert!(self.is_valid());
-                self.maybe_change_value(Miny::new(casts.r_unit.cast(())), state)
+                self.maybe_change_value(Miny::new_unsized(casts.r_unit.cast(())), state)
             }
             Kind::BindMain { casts, bind, .. } => {
                 let rhs = bind.rhs.borrow().as_ref().unwrap().clone();
                 self.copy_child_bindrhs(&rhs.node, casts.rhs_r, state)
             }
-            Kind::ArrayFold(af) => self.maybe_change_value(Miny::new(af.compute()), state),
+            Kind::ArrayFold(af) => self.maybe_change_value(Miny::new_unsized(af.compute()), state),
             Kind::Expert(e) => match e.before_main_computation() {
                 Err(Invalid) => {
                     self.invalidate_node(state);
@@ -895,7 +906,7 @@ impl<G: NodeGenerics> ErasedNode for Node<G> {
                 Ok(()) => {
                     let value = {
                         if let Some(r) = e.recompute.borrow_mut().as_mut() {
-                            Miny::new(r())
+                            Miny::new_unsized(r())
                         } else {
                             panic!()
                         }
@@ -1624,7 +1635,7 @@ impl<G: NodeGenerics> Node<G> {
         Some(&self._kind)
     }
 
-    fn maybe_change_value(&self, value: Miny<G::R>, state: &State) -> Option<NodeRef> {
+    fn maybe_change_value(&self, value: Miny<dyn Any>, state: &State) -> Option<NodeRef> {
         let old_value_opt = self.value_opt.take();
         let mut cutoff = self.cutoff.borrow_mut();
         let should_change = old_value_opt
@@ -1781,7 +1792,7 @@ impl<G: NodeGenerics> Node<G> {
     ) -> Option<NodeRef> {
         if child.is_valid() {
             let latest = child.latest();
-            self.maybe_change_value(Miny::new(token.cast(latest)), state)
+            self.maybe_change_value(Miny::new_unsized(token.cast(latest)), state)
         } else {
             self.invalidate_node(state);
             state.propagate_invalidity();

--- a/src/node.rs
+++ b/src/node.rs
@@ -707,7 +707,7 @@ impl<G: NodeGenerics> ErasedNode for Node<G> {
                 let new_value = f(&*i1, &*i2, &*i3, &*i4, &*i5, &*i6);
                 self.maybe_change_value(Miny::new_unsized(new_value), state)
             }
-            Kind::BindLhsChange { casts, bind } => {
+            Kind::BindLhsChange { bind } => {
                 // leaves an empty vec for next time
                 // TODO: we could double-buffer this to save allocations.
                 let mut old_all_nodes_created_on_rhs = bind.all_nodes_created_on_rhs.take();
@@ -762,7 +762,7 @@ impl<G: NodeGenerics> ErasedNode for Node<G> {
                 /* [node] was valid at the start of the [Bind_lhs_change] branch, and invalidation
                 only visits higher nodes, so [node] is still valid. */
                 debug_assert!(self.is_valid());
-                self.maybe_change_value(Miny::new_unsized(casts.r_unit.cast(())), state)
+                self.maybe_change_value(Miny::new_unsized(()), state)
             }
             Kind::BindMain { bind, .. } => {
                 let rhs = bind.rhs.borrow();

--- a/src/node.rs
+++ b/src/node.rs
@@ -48,7 +48,7 @@ pub(crate) struct Node<G: NodeGenerics> {
     pub is_valid: Cell<bool>,
     // Don't use this field directly. Use `self::kind()` to be forced to confront
     // the !is_valid case.
-    pub _kind: Kind<G>,
+    _kind: Kind<G>,
     /// The cutoff function. This determines whether we set `changed_at = recomputed_at` during
     /// recomputation, which in turn helps determine if our parents are stale & need recomputing
     /// themselves.

--- a/src/node.rs
+++ b/src/node.rs
@@ -341,7 +341,6 @@ impl fmt::Display for ParentError {
 
 pub(crate) trait ErasedNode: Debug + NotObserver {
     fn id(&self) -> NodeId;
-    fn ptr_eq(&self, other: &dyn ErasedNode) -> bool;
     fn kind_debug_ty(&self) -> String;
     fn weak_state(&self) -> &Weak<State>;
     fn is_valid(&self) -> bool;
@@ -449,12 +448,15 @@ impl<G: NodeGenerics> Debug for Node<G> {
     }
 }
 
+impl dyn ErasedNode {
+    fn ptr_eq(&self, other: &dyn ErasedNode) -> bool {
+        self.weak().ptr_eq(&other.weak())
+    }
+}
+
 impl<G: NodeGenerics> ErasedNode for Node<G> {
     fn id(&self) -> NodeId {
         self.id
-    }
-    fn ptr_eq(&self, other: &dyn ErasedNode) -> bool {
-        self.weak().ptr_eq(&other.weak())
     }
     fn kind_debug_ty(&self) -> String {
         let Some(dbg) = self.kind().map(|k| k.debug_ty()) else {

--- a/src/node.rs
+++ b/src/node.rs
@@ -848,12 +848,12 @@ impl<G: NodeGenerics> ErasedNode for Node<G> {
                 // leaves an empty vec for next time
                 // TODO: we could double-buffer this to save allocations.
                 let mut old_all_nodes_created_on_rhs = bind.all_nodes_created_on_rhs.take();
-                let lhs = bind.lhs.value_as_ref().unwrap();
+                let lhs = bind.lhs.value_as_any().unwrap();
                 let rhs = {
                     let old_scope = state.current_scope();
                     *state.current_scope.borrow_mut() = bind.rhs_scope.borrow().clone();
                     let mut f = bind.mapper.borrow_mut();
-                    let rhs = f(&lhs);
+                    let rhs = f(&*lhs);
                     *state.current_scope.borrow_mut() = old_scope;
                     // Check that the returned RHS node is from the same world.
                     assert!(crate::weak_thin_ptr_eq(

--- a/src/node.rs
+++ b/src/node.rs
@@ -165,7 +165,7 @@ impl<G: NodeGenerics> Incremental<G::R> for Node<G> {
     }
     fn constant(&self) -> Option<&G::R> {
         if let Some(Kind::Constant(value)) = self.kind() {
-            Some(value)
+            value.downcast_ref()
         } else {
             None
         }
@@ -642,7 +642,10 @@ impl<G: NodeGenerics> ErasedNode for Node<G> {
                 };
                 self.maybe_change_value(new_value, state)
             }
-            Kind::Constant(v) => self.maybe_change_value(Miny::new_unsized(v.clone()), state),
+            Kind::Constant(v) => {
+                let x = v.downcast_ref::<G::R>().unwrap();
+                self.maybe_change_value(Miny::new_unsized(x.clone()), state)
+            }
             Kind::MapRef(mapref) => {
                 // don't run child_changed on our parents, because we already did that in OUR child_changed.
                 self.value_opt.replace(None);

--- a/src/node.rs
+++ b/src/node.rs
@@ -631,8 +631,8 @@ impl<G: NodeGenerics> ErasedNode for Node<G> {
             Kind::Map(map) => {
                 let new_value = {
                     let mut f = map.mapper.borrow_mut();
-                    let input = map.input.value_as_ref().unwrap();
-                    f(&input)
+                    let input = map.input.value_as_any().unwrap();
+                    f(&*input)
                 };
                 self.maybe_change_value(Miny::new_unsized(new_value), state)
             }
@@ -664,48 +664,48 @@ impl<G: NodeGenerics> ErasedNode for Node<G> {
                 self.maybe_change_value_manual(None, did_change, true, state)
             }
             Kind::Map2(map2) => {
-                let i1 = map2.one.value_as_ref().unwrap();
-                let i2 = map2.two.value_as_ref().unwrap();
+                let i1 = map2.one.value_as_any().unwrap();
+                let i2 = map2.two.value_as_any().unwrap();
                 let mut f = map2.mapper.borrow_mut();
-                let new_value = f(&i1, &i2);
+                let new_value = f(&*i1, &*i2);
                 self.maybe_change_value(Miny::new_unsized(new_value), state)
             }
             Kind::Map3(map) => {
-                let i1 = map.one.value_as_ref().unwrap();
-                let i2 = map.two.value_as_ref().unwrap();
-                let i3 = map.three.value_as_ref().unwrap();
+                let i1 = map.one.value_as_any().unwrap();
+                let i2 = map.two.value_as_any().unwrap();
+                let i3 = map.three.value_as_any().unwrap();
                 let mut f = map.mapper.borrow_mut();
-                let new_value = f(&i1, &i2, &i3);
+                let new_value = f(&*i1, &*i2, &*i3);
                 self.maybe_change_value(Miny::new_unsized(new_value), state)
             }
             Kind::Map4(map) => {
-                let i1 = map.one.value_as_ref().unwrap();
-                let i2 = map.two.value_as_ref().unwrap();
-                let i3 = map.three.value_as_ref().unwrap();
-                let i4 = map.four.value_as_ref().unwrap();
+                let i1 = map.one.value_as_any().unwrap();
+                let i2 = map.two.value_as_any().unwrap();
+                let i3 = map.three.value_as_any().unwrap();
+                let i4 = map.four.value_as_any().unwrap();
                 let mut f = map.mapper.borrow_mut();
-                let new_value = f(&i1, &i2, &i3, &i4);
+                let new_value = f(&*i1, &*i2, &*i3, &*i4);
                 self.maybe_change_value(Miny::new_unsized(new_value), state)
             }
             Kind::Map5(map) => {
-                let i1 = map.one.value_as_ref().unwrap();
-                let i2 = map.two.value_as_ref().unwrap();
-                let i3 = map.three.value_as_ref().unwrap();
-                let i4 = map.four.value_as_ref().unwrap();
-                let i5 = map.five.value_as_ref().unwrap();
+                let i1 = map.one.value_as_any().unwrap();
+                let i2 = map.two.value_as_any().unwrap();
+                let i3 = map.three.value_as_any().unwrap();
+                let i4 = map.four.value_as_any().unwrap();
+                let i5 = map.five.value_as_any().unwrap();
                 let mut f = map.mapper.borrow_mut();
-                let new_value = f(&i1, &i2, &i3, &i4, &i5);
+                let new_value = f(&*i1, &*i2, &*i3, &*i4, &*i5);
                 self.maybe_change_value(Miny::new_unsized(new_value), state)
             }
             Kind::Map6(map) => {
-                let i1 = map.one.value_as_ref().unwrap();
-                let i2 = map.two.value_as_ref().unwrap();
-                let i3 = map.three.value_as_ref().unwrap();
-                let i4 = map.four.value_as_ref().unwrap();
-                let i5 = map.five.value_as_ref().unwrap();
-                let i6 = map.six.value_as_ref().unwrap();
+                let i1 = map.one.value_as_any().unwrap();
+                let i2 = map.two.value_as_any().unwrap();
+                let i3 = map.three.value_as_any().unwrap();
+                let i4 = map.four.value_as_any().unwrap();
+                let i5 = map.five.value_as_any().unwrap();
+                let i6 = map.six.value_as_any().unwrap();
                 let mut f = map.mapper.borrow_mut();
-                let new_value = f(&i1, &i2, &i3, &i4, &i5, &i6);
+                let new_value = f(&*i1, &*i2, &*i3, &*i4, &*i5, &*i6);
                 self.maybe_change_value(Miny::new_unsized(new_value), state)
             }
             Kind::BindLhsChange { casts, bind } => {
@@ -1519,9 +1519,9 @@ impl<G: NodeGenerics> Node<G> {
         let mut ret = init;
         match kind {
             Kind::Constant(_) => {}
-            Kind::Map(kind::MapNode { input, .. })
-            | Kind::MapRef(kind::MapRefNode { input, .. })
+            Kind::MapRef(kind::MapRefNode { input, .. })
             | Kind::MapWithOld(kind::MapWithOld { input, .. }) => ret = f(ret, 0, input.packed())?,
+            Kind::Map(kind::MapNode { input, .. }) => ret = f(ret, 0, input.clone())?,
             Kind::Map2(kind::Map2Node { one, two, .. }) => {
                 ret = f(ret, 0, one.clone().packed())?;
                 ret = f(ret, 1, two.clone().packed())?;

--- a/src/node.rs
+++ b/src/node.rs
@@ -1569,7 +1569,7 @@ impl<G: NodeGenerics> Node<G> {
             Kind::BindMain {
                 bind, lhs_change, ..
             } => {
-                ret = f(ret, 0, lhs_change.packed())?;
+                ret = f(ret, 0, lhs_change.clone())?;
                 if let Some(rhs) = bind.rhs.borrow().as_ref() {
                     ret = f(ret, 1, rhs.clone())?;
                 }

--- a/src/node.rs
+++ b/src/node.rs
@@ -157,7 +157,7 @@ impl<G: NodeGenerics> Incremental<G::R> for Node<G> {
         if let Some(Kind::MapRef(mapref)) = self.kind() {
             let mapper = &*mapref.mapper;
             let input = mapref.input.value_as_any()?;
-            let mapped = Ref::filter_map(input, |iref| Some(mapper(iref))).ok();
+            let mapped = Ref::filter_map(input, |iref| mapper(iref).downcast_ref()).ok();
             return mapped;
         }
         let v = self.value_opt.borrow();

--- a/src/node.rs
+++ b/src/node.rs
@@ -26,26 +26,8 @@ use std::{
     rc::Rc,
 };
 
-#[derive(Copy, Clone, PartialEq, Eq, Hash)]
-pub struct NodeId(pub(crate) usize);
-impl NodeId {
-    fn next() -> Self {
-        thread_local! {
-            static NODE_ID: Cell<usize> = Cell::new(0);
-        }
-
-        NODE_ID.with(|x| {
-            let next = x.get() + 1;
-            x.set(next);
-            NodeId(next)
-        })
-    }
-}
-impl fmt::Debug for NodeId {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "id={}", self.0)
-    }
-}
+mod id;
+pub(crate) use self::id::NodeId;
 
 #[repr(C)]
 pub(crate) struct Node<G: NodeGenerics> {

--- a/src/node/id.rs
+++ b/src/node/id.rs
@@ -1,0 +1,23 @@
+use std::cell::Cell;
+use std::fmt;
+
+#[derive(Copy, Clone, PartialEq, Eq, Hash)]
+pub struct NodeId(pub(crate) usize);
+impl NodeId {
+    pub(super) fn next() -> Self {
+        thread_local! {
+            static NODE_ID: Cell<usize> = Cell::new(0);
+        }
+
+        NODE_ID.with(|x| {
+            let next = x.get() + 1;
+            x.set(next);
+            NodeId(next)
+        })
+    }
+}
+impl fmt::Debug for NodeId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}

--- a/src/node_update.rs
+++ b/src/node_update.rs
@@ -1,13 +1,13 @@
 use std::cell::Cell;
 
 use super::stabilisation_num::StabilisationNum;
-use crate::node::ErasedNode;
+use crate::{boxes::SmallBox, node::ErasedNode};
 
 #[cfg(not(feature = "nightly-incrsan"))]
-pub(crate) type BoxedUpdateFn<T> = miny::Miny<dyn FnMut(NodeUpdate<&T>)>;
+pub(crate) type BoxedUpdateFn<T> = SmallBox<dyn FnMut(NodeUpdate<&T>)>;
 #[cfg(feature = "nightly-incrsan")]
 pub(crate) type BoxedUpdateFn<T> =
-    miny::Miny<dyn FnMut(NodeUpdate<&T>) + crate::incrsan::NotObserver>;
+    SmallBox<dyn FnMut(NodeUpdate<&T>) + crate::incrsan::NotObserver>;
 
 #[derive(Copy, Clone, PartialEq, Eq, Hash, Debug)]
 enum Previously {

--- a/src/node_update.rs
+++ b/src/node_update.rs
@@ -64,12 +64,18 @@ impl<T: 'static> OnUpdateHandler<T> {
         let concrete_update = match node_update {
             NodeUpdateDelayed::Changed => {
                 let value_any = value_any.unwrap();
-                let v = value_any.downcast_ref::<T>().expect("downcast_ref failed");
+                let v = value_any
+                    .as_any()
+                    .downcast_ref::<T>()
+                    .expect("downcast_ref failed");
                 return (self.handler_fn)(NodeUpdate::Changed(&*v));
             }
             NodeUpdateDelayed::Necessary => {
                 let value_any = value_any.unwrap();
-                let v = value_any.downcast_ref::<T>().expect("downcast_ref failed");
+                let v = value_any
+                    .as_any()
+                    .downcast_ref::<T>()
+                    .expect("downcast_ref failed");
                 return (self.handler_fn)(NodeUpdate::Necessary(&*v));
             }
             NodeUpdateDelayed::Invalidated => NodeUpdate::Invalidated,

--- a/src/node_update.rs
+++ b/src/node_update.rs
@@ -4,9 +4,10 @@ use super::stabilisation_num::StabilisationNum;
 use crate::node::ErasedNode;
 
 #[cfg(not(feature = "nightly-incrsan"))]
-pub(crate) type BoxedUpdateFn<T> = Box<dyn FnMut(NodeUpdate<&T>)>;
+pub(crate) type BoxedUpdateFn<T> = miny::Miny<dyn FnMut(NodeUpdate<&T>)>;
 #[cfg(feature = "nightly-incrsan")]
-pub(crate) type BoxedUpdateFn<T> = Box<dyn FnMut(NodeUpdate<&T>) + crate::incrsan::NotObserver>;
+pub(crate) type BoxedUpdateFn<T> =
+    miny::Miny<dyn FnMut(NodeUpdate<&T>) + crate::incrsan::NotObserver>;
 
 #[derive(Copy, Clone, PartialEq, Eq, Hash, Debug)]
 enum Previously {

--- a/src/node_update.rs
+++ b/src/node_update.rs
@@ -1,16 +1,13 @@
 use std::cell::Cell;
 
 use super::stabilisation_num::StabilisationNum;
-use crate::{
-    boxes::SmallBox,
-    node::{ErasedNode, Node},
-};
+use crate::boxes::SmallBox;
+use crate::incrsan::not_observer_boxed_trait;
+use crate::node::{ErasedNode, Node};
 
-#[cfg(not(feature = "nightly-incrsan"))]
-pub(crate) type BoxedUpdateFn<T> = SmallBox<dyn FnMut(NodeUpdate<&T>)>;
-#[cfg(feature = "nightly-incrsan")]
-pub(crate) type BoxedUpdateFn<T> =
-    SmallBox<dyn FnMut(NodeUpdate<&T>) + crate::incrsan::NotObserver>;
+not_observer_boxed_trait! {
+    pub(crate) type BoxedUpdateFn<T> = SmallBox<dyn (FnMut(NodeUpdate<&T>))>;
+}
 
 #[derive(Copy, Clone, PartialEq, Eq, Hash, Debug)]
 enum Previously {
@@ -37,7 +34,9 @@ pub enum NodeUpdate<T> {
     Unnecessary,
 }
 
-pub(crate) type ErasedOnUpdateHandler = Box<dyn HandleUpdate>;
+not_observer_boxed_trait! {
+    pub(crate) type ErasedOnUpdateHandler = Box<dyn (HandleUpdate)>;
+}
 
 pub(crate) trait HandleUpdate {
     fn run(&mut self, node: &Node, node_update: NodeUpdateDelayed, now: StabilisationNum);

--- a/src/public.rs
+++ b/src/public.rs
@@ -6,8 +6,6 @@ use std::hash::Hash;
 use std::ops::{Deref, Sub};
 use std::rc::{Rc, Weak};
 
-use miny::Miny;
-
 pub use super::cutoff::Cutoff;
 pub use super::incr::{Incr, WeakIncr};
 pub use super::internal_observer::{ObserverError, SubscriptionToken};
@@ -22,6 +20,7 @@ use super::node_update::OnUpdateHandler;
 use super::scope;
 use super::state::State;
 use super::var::{ErasedVariable, Var as InternalVar};
+use crate::boxes::new_unsized;
 use crate::incrsan::NotObserver;
 
 #[derive(Clone)]
@@ -96,7 +95,7 @@ impl<T: Value> Observer<T> {
         &self,
         mut on_update: impl FnMut(Update<&T>) + 'static + NotObserver,
     ) -> Result<SubscriptionToken, ObserverError> {
-        let handler_fn = Miny::new_unsized(move |node_update: NodeUpdate<&T>| {
+        let handler_fn = new_unsized!(move |node_update: NodeUpdate<&T>| {
             let update = match node_update {
                 NodeUpdate::Necessary(t) => Update::Initialised(t),
                 NodeUpdate::Changed(t) => Update::Changed(t),

--- a/src/public.rs
+++ b/src/public.rs
@@ -15,6 +15,7 @@ pub use super::node_update::NodeUpdate;
 pub use super::Value;
 
 use super::internal_observer::{ErasedObserver, InternalObserver};
+use super::node::ErasedNode;
 use super::node::NodeId;
 use super::node_update::OnUpdateHandler;
 use super::scope;

--- a/src/public.rs
+++ b/src/public.rs
@@ -6,6 +6,8 @@ use std::hash::Hash;
 use std::ops::{Deref, Sub};
 use std::rc::{Rc, Weak};
 
+use miny::Miny;
+
 pub use super::cutoff::Cutoff;
 pub use super::incr::{Incr, WeakIncr};
 pub use super::internal_observer::{ObserverError, SubscriptionToken};
@@ -94,7 +96,7 @@ impl<T: Value> Observer<T> {
         &self,
         mut on_update: impl FnMut(Update<&T>) + 'static + NotObserver,
     ) -> Result<SubscriptionToken, ObserverError> {
-        let handler_fn = Box::new(move |node_update: NodeUpdate<&T>| {
+        let handler_fn = Miny::new_unsized(move |node_update: NodeUpdate<&T>| {
             let update = match node_update {
                 NodeUpdate::Necessary(t) => Update::Initialised(t),
                 NodeUpdate::Changed(t) => Update::Changed(t),

--- a/src/recompute_heap.rs
+++ b/src/recompute_heap.rs
@@ -1,3 +1,4 @@
+use crate::node::ErasedNode;
 use crate::CellIncrement;
 use crate::NodeRef;
 use std::cell::{Cell, Ref, RefCell};

--- a/src/scope.rs
+++ b/src/scope.rs
@@ -3,6 +3,7 @@ use std::rc::Weak;
 
 use super::{node::NodeId, NodeRef, WeakNode};
 use crate::incrsan::NotObserver;
+use crate::node::ErasedNode;
 
 pub(crate) trait BindScope: fmt::Debug + NotObserver {
     fn id(&self) -> NodeId;

--- a/src/state.rs
+++ b/src/state.rs
@@ -4,6 +4,7 @@ use super::node_update::NodeUpdateDelayed;
 use super::{CellIncrement, NodeRef, Value, WeakNode};
 use crate::boxes::new_unsized;
 use crate::incrsan::NotObserver;
+use crate::node::ErasedNode;
 use crate::{SubscriptionToken, WeakMap};
 
 use super::internal_observer::{

--- a/src/state.rs
+++ b/src/state.rs
@@ -1,9 +1,8 @@
-use miny::Miny;
-
 use super::adjust_heights_heap::AdjustHeightsHeap;
 use super::kind;
 use super::node_update::NodeUpdateDelayed;
 use super::{CellIncrement, NodeRef, Value, WeakNode};
+use crate::boxes::new_unsized;
 use crate::incrsan::NotObserver;
 use crate::{SubscriptionToken, WeakMap};
 
@@ -181,7 +180,7 @@ impl State {
         let node = Node::create_rc::<R>(
             self.weak(),
             self.current_scope(),
-            Kind::ArrayFold(Miny::new_unsized(kind::ArrayFold {
+            Kind::ArrayFold(new_unsized!(kind::ArrayFold {
                 init,
                 fold: RefCell::new(f),
                 children: vec,

--- a/src/state.rs
+++ b/src/state.rs
@@ -180,12 +180,12 @@ impl State {
         if vec.is_empty() {
             return self.constant(init);
         }
-        let node = Node::<kind::ArrayFold<F, T, R>>::create_rc(
+        let node = Node::<kind::ArrayFold<T, R>>::create_rc(
             self.weak(),
             self.current_scope(),
             Kind::ArrayFold(kind::ArrayFold {
                 init,
-                fold: f.into(),
+                fold: RefCell::new(Box::new(f)),
                 children: vec,
             }),
         );

--- a/src/state.rs
+++ b/src/state.rs
@@ -1,3 +1,5 @@
+use miny::Miny;
+
 use super::adjust_heights_heap::AdjustHeightsHeap;
 use super::kind;
 use super::node_update::NodeUpdateDelayed;
@@ -179,9 +181,9 @@ impl State {
         let node = Node::create_rc::<R>(
             self.weak(),
             self.current_scope(),
-            Kind::ArrayFold(Box::new(kind::ArrayFold {
+            Kind::ArrayFold(Miny::new_unsized(kind::ArrayFold {
                 init,
-                fold: RefCell::new(Box::new(f)),
+                fold: RefCell::new(f),
                 children: vec,
             })),
         );

--- a/src/state.rs
+++ b/src/state.rs
@@ -163,7 +163,7 @@ impl State {
         let node = Node::<Constant<T>>::create_rc(
             self.weak(),
             self.current_scope(),
-            Kind::Constant(value),
+            Kind::<Constant<T>>::constant(value),
         );
         Incr { node }
     }

--- a/src/state.rs
+++ b/src/state.rs
@@ -180,14 +180,14 @@ impl State {
         if vec.is_empty() {
             return self.constant(init);
         }
-        let node = Node::<kind::ArrayFold<T, R>>::create_rc(
+        let node = Node::<kind::ArrayFold<F, T, R>>::create_rc(
             self.weak(),
             self.current_scope(),
-            Kind::ArrayFold(kind::ArrayFold {
+            Kind::ArrayFold(Box::new(kind::ArrayFold {
                 init,
                 fold: RefCell::new(Box::new(f)),
                 children: vec,
-            }),
+            })),
         );
         Incr { node }
     }

--- a/src/state.rs
+++ b/src/state.rs
@@ -8,7 +8,7 @@ use crate::{SubscriptionToken, WeakMap};
 use super::internal_observer::{
     ErasedObserver, InternalObserver, ObserverId, ObserverState, StrongObserver, WeakObserver,
 };
-use super::kind::{Constant, Kind};
+use super::kind::Kind;
 use super::node::{Node, NodeId};
 use super::recompute_heap::RecomputeHeap;
 use super::scope::Scope;
@@ -160,11 +160,7 @@ impl State {
         //       - make recompute a noop instead of a clone
         //       - set recomputed_at/changed_at to avoid queueing for recompute at all?
         //       to save the single clone that constant currently does.
-        let node = Node::<Constant<T>>::create_rc(
-            self.weak(),
-            self.current_scope(),
-            Kind::<Constant<T>>::constant(value),
-        );
+        let node = Node::create_rc::<T>(self.weak(), self.current_scope(), Kind::constant(value));
         Incr { node }
     }
 
@@ -180,7 +176,7 @@ impl State {
         if vec.is_empty() {
             return self.constant(init);
         }
-        let node = Node::<kind::ArrayFold<F, T, R>>::create_rc(
+        let node = Node::create_rc::<R>(
             self.weak(),
             self.current_scope(),
             Kind::ArrayFold(Box::new(kind::ArrayFold {
@@ -205,11 +201,7 @@ impl State {
             node: RefCell::new(None),
             value_set_during_stabilisation: RefCell::new(None),
         });
-        let node = Node::<super::var::VarGenerics<T>>::create_rc(
-            self.weak(),
-            scope,
-            Kind::Var(var.clone()),
-        );
+        let node = Node::create_rc::<T>(self.weak(), scope, Kind::Var(var.clone()));
         {
             let mut slot = var.node.borrow_mut();
             var.node_id.set(node.id);

--- a/src/state/expert.rs
+++ b/src/state/expert.rs
@@ -10,7 +10,7 @@ where
     F: FnMut() -> T + 'static + NotObserver,
     O: FnMut(bool) + 'static + NotObserver,
 {
-    let node = Node::<kind::ExpertNode<T, F, O>>::create_rc(
+    let node = Node::<kind::ExpertNode<T, F>>::create_rc(
         state.weak(),
         state.current_scope(),
         Kind::Expert(kind::ExpertNode::new_obs(
@@ -43,7 +43,7 @@ where
     let node = Rc::<Node<_>>::new_cyclic(|weak| {
         let weak_incr = WeakIncr(weak.clone());
         let recompute = cyclic(weak_incr);
-        let mut node = Node::<kind::ExpertNode<T, F, O>>::create(
+        let mut node = Node::<kind::ExpertNode<T, F>>::create(
             state.weak(),
             state.current_scope(),
             Kind::Expert(kind::ExpertNode::new_obs(

--- a/src/state/expert.rs
+++ b/src/state/expert.rs
@@ -1,5 +1,6 @@
 use super::*;
 use crate::kind::{self, expert::ExpertEdge};
+use crate::node::ErasedNode;
 use crate::node::Incremental;
 use crate::WeakIncr;
 use kind::expert::PackedEdge;

--- a/src/state/expert.rs
+++ b/src/state/expert.rs
@@ -10,7 +10,7 @@ where
     F: FnMut() -> T + 'static + NotObserver,
     O: FnMut(bool) + 'static + NotObserver,
 {
-    let node = Node::<kind::ExpertNode<T, F>>::create_rc(
+    let node = Node::<kind::ExpertNode<T>>::create_rc(
         state.weak(),
         state.current_scope(),
         Kind::Expert(kind::ExpertNode::new_obs(
@@ -43,7 +43,7 @@ where
     let node = Rc::<Node<_>>::new_cyclic(|weak| {
         let weak_incr = WeakIncr(weak.clone());
         let recompute = cyclic(weak_incr);
-        let mut node = Node::<kind::ExpertNode<T, F>>::create(
+        let mut node = Node::<kind::ExpertNode<T>>::create(
             state.weak(),
             state.current_scope(),
             Kind::Expert(kind::ExpertNode::new_obs(

--- a/src/state/expert.rs
+++ b/src/state/expert.rs
@@ -10,7 +10,7 @@ where
     F: FnMut() -> T + 'static + NotObserver,
     O: FnMut(bool) + 'static + NotObserver,
 {
-    let node = Node::<kind::ExpertNode<T>>::create_rc(
+    let node = Node::create_rc::<T>(
         state.weak(),
         state.current_scope(),
         Kind::Expert(kind::ExpertNode::new_obs(
@@ -40,10 +40,10 @@ where
     F: FnMut() -> T + 'static + NotObserver,
     O: FnMut(bool) + 'static + NotObserver,
 {
-    let node = Rc::<Node<_>>::new_cyclic(|weak| {
+    let node = Rc::<Node>::new_cyclic(|weak| {
         let weak_incr = WeakIncr(weak.clone());
         let recompute = cyclic(weak_incr);
-        let mut node = Node::<kind::ExpertNode<T>>::create(
+        let mut node = Node::create::<T>(
             state.weak(),
             state.current_scope(),
             Kind::Expert(kind::ExpertNode::new_obs(

--- a/src/state/expert.rs
+++ b/src/state/expert.rs
@@ -1,8 +1,8 @@
 use super::*;
-use crate::kind;
+use crate::kind::{self, expert::ExpertEdge};
 use crate::node::Incremental;
 use crate::WeakIncr;
-use kind::expert::{IsEdge, PackedEdge};
+use kind::expert::PackedEdge;
 
 pub(crate) fn create<T, F, O>(state: &State, recompute: F, on_observability_change: O) -> Incr<T>
 where
@@ -74,6 +74,6 @@ pub(crate) fn add_dependency(node: &NodeRef, edge: PackedEdge) {
     node.expert_add_dependency(edge);
 }
 
-pub(crate) fn remove_dependency<T>(node: &dyn Incremental<T>, dyn_edge: &dyn IsEdge) {
+pub(crate) fn remove_dependency<T>(node: &dyn Incremental<T>, dyn_edge: &dyn ExpertEdge) {
     node.expert_remove_dependency(dyn_edge);
 }

--- a/src/var.rs
+++ b/src/var.rs
@@ -5,7 +5,6 @@ use std::rc::{Rc, Weak};
 #[cfg(test)]
 use test_log::test;
 
-use super::kind::NodeGenerics;
 use super::node::{ErasedNode, Incremental, Node, NodeId};
 use super::stabilisation_num::StabilisationNum;
 use super::state::IncrStatus;
@@ -14,17 +13,8 @@ use super::CellIncrement;
 use super::Incr;
 use crate::incrsan::NotObserver;
 use crate::kind::KindTrait;
-use crate::node_generics_default;
 use crate::Value;
-
-pub(crate) struct VarGenerics<T: Value>(std::marker::PhantomData<T>);
-impl<R: Value> NodeGenerics for VarGenerics<R> {
-    type R = R;
-    node_generics_default! { I1, I2, I3, I4, I5, I6 }
-    node_generics_default! { F1, F2, F3, F4, F5, F6 }
-    node_generics_default! { B1, BindLhs, BindRhs }
-    node_generics_default! { Fold, Update, WithOld, FRef, Recompute, ObsChange }
-}
+use crate::ValueInternal;
 
 // For the delayed variable set list (set_during_stabilisation).
 // We use Weak to ensure we don't interfere with the manual
@@ -59,7 +49,7 @@ impl<T: Value> ErasedVariable for Var<T> {
 }
 
 impl<T: Value> KindTrait for Var<T> {
-    fn compute(&self) -> miny::Miny<dyn std::any::Any> {
+    fn compute(&self) -> miny::Miny<dyn ValueInternal> {
         miny::Miny::new_unsized((*self.value.borrow()).clone())
     }
 
@@ -87,7 +77,7 @@ pub struct Var<T: Value> {
     pub(crate) value_set_during_stabilisation: RefCell<Option<T>>,
     pub(crate) set_at: Cell<StabilisationNum>,
     // mutable for initialisation
-    pub(crate) node: RefCell<Option<Rc<Node<VarGenerics<T>>>>>,
+    pub(crate) node: RefCell<Option<Rc<Node>>>,
     // mutable for initialisation
     pub(crate) node_id: Cell<NodeId>,
 }

--- a/src/var.rs
+++ b/src/var.rs
@@ -11,6 +11,7 @@ use super::state::IncrStatus;
 use super::state::State;
 use super::CellIncrement;
 use super::Incr;
+use crate::boxes::{new_unsized, SmallBox};
 use crate::incrsan::NotObserver;
 use crate::kind::KindTrait;
 use crate::Value;
@@ -49,8 +50,8 @@ impl<T: Value> ErasedVariable for Var<T> {
 }
 
 impl<T: Value> KindTrait for Var<T> {
-    fn compute(&self) -> miny::Miny<dyn ValueInternal> {
-        miny::Miny::new_unsized((*self.value.borrow()).clone())
+    fn compute(&self) -> SmallBox<dyn ValueInternal> {
+        new_unsized!((*self.value.borrow()).clone())
     }
 
     fn children_len(&self) -> usize {

--- a/tests/fixed_point.rs
+++ b/tests/fixed_point.rs
@@ -269,7 +269,6 @@ fn two_fixedpoints_combined() {
     assert_eq!(combined.value(), 0);
 }
 
-#[cfg(feature = "im")]
 #[test]
 fn transitive_closure() {
     use im_rc::{hashmap, hashset, HashMap, HashSet};
@@ -346,7 +345,6 @@ where
     (output, until)
 }
 
-#[cfg(feature = "im")]
 mod transitive_closure {
     use super::*;
     use im_rc::{hashmap, hashset, HashMap, HashSet};


### PR DESCRIPTION
Previously, pretty much any time you used an API on `Incr`, like `Incr::map`, rustc would basically have to compile the entire crate again. Because each closure was a new MapNode<F>, and each MapNode is a new NodeGenerics. This was the cause of pretty horrific compile times on any non-trivial project, including incremental's own test suite.

This was due to feeding through generic parameters all the way into Node, which was due to a misunderstanding on my part of how the ocaml compiler works. It checks types at compile time but nevertheless has runtime polymorphism. There is, for example, only one copy of `Node.recompute` in an OCaml binary. So rust generics are a bad way to emulate this.

Instead, this PR erases all generics except in the public APIs. All map functions are now boxed; all values are now boxed. There are trait objects everywhere. Runtime performance suffers, by between 10 and 70% on the microbenchmarks and negligible change to real-world perf. I imagine in bigger projects there will be a perf benefit to having only one copy of Node, which is MUCH friendlier to the instruction cache than *109 copies of Node and all its methods* etc. (Aside from  being able to compile your project in under 30 minutes, which is a perf win in its own way.)

This PR has no public API changes.

### Performance

If you do a lot of `Incr<f32>` and other types that are `usize` or smaller, then you will benefit from the `nightly-miny` feature. This swaps out std's Box for [`miny::Miny`](https://github.com/1e1001/miny). That crate is nightly-only, hence the feature name. It is between 10 and 30% faster than stock `incremental` on the `linear` benchmarks. In fact it is faster than before this PR on most of them. But unless all your map nodes are integer additions like in those microbenchmarks, then you're probably fine.

### Compile times

#### Before

```sh
; touch tests/basic.rs
; CARGO_INCREMENTAL=false cargo build --test basic
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 10.23s
; CARGO_INCREMENTAL=false cargo build --test basic --release
    Finished `release` profile [optimized] target(s) in 48.56s
```

#### After

```sh
; touch tests/basic.rs
; CARGO_INCREMENTAL=false cargo build --test basic
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.84s
; CARGO_INCREMENTAL=false cargo build --test basic --release
    Finished `release` profile [optimized] target(s) in 5.21s
```

